### PR TITLE
http 4xx 状态码，通过开关配置是否设置为error状态，默认不开启，主要通过设置 #100

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -65,6 +65,10 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     SERVER_PATHWAY_EDGE_TAGS.put("type", "http");
   }
 
+  private static final BitSet CLIENT_ERROR_STATUSES = Config.get().getHttpClientErrorStatuses();
+
+  private static final Boolean HTTP_ERROR_ENBALED = Config.get().isHttpErrorEnabled();
+
   private static final UTF8BytesString DEFAULT_RESOURCE_NAME = UTF8BytesString.create("/");
   protected static final UTF8BytesString NOT_FOUND_RESOURCE_NAME = UTF8BytesString.create("404");
   private static final boolean SHOULD_SET_404_RESOURCE_NAME =
@@ -306,6 +310,9 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   public AgentSpan onResponseStatus(final AgentSpan span, final int status) {
     if (status > UNSET_STATUS) {
       span.setHttpStatusCode(status);
+      if (HTTP_ERROR_ENBALED && CLIENT_ERROR_STATUSES.get(status)) {
+        span.setError(true);
+      }else
       // explicitly set here because some other decorators might already set an error without
       // looking at the status code
       // XXX: the logic is questionable: span.error becomes equivalent to status 5xx,

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -256,5 +256,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_TRACE_DUBBO_PROVIDER_PROPAGATE_ENABLED = false;
 
+  static final boolean DEFAULT_HTTP_ERROR_ENABLED = false;
+
   private ConfigDefaults() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -68,6 +68,8 @@ public final class TracerConfig {
   public static final String HTTP_SERVER_ERROR_STATUSES = "http.server.error.statuses";
   public static final String HTTP_CLIENT_ERROR_STATUSES = "http.client.error.statuses";
 
+  public static final String HTTP_ERROR_ENABLED = "http.error.enabled";
+
   public static final String SPLIT_BY_TAGS = "trace.split-by-tags";
 
   public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -139,6 +139,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RESOLVER_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RESPONSE_BODY_ENCODING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_WRITER_BAGGAGE_INJECT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_ERROR_ENABLED;
 import static datadog.trace.api.DDTags.APM_ENABLED;
 import static datadog.trace.api.DDTags.HOST_TAG;
 import static datadog.trace.api.DDTags.INTERNAL_HOST_NAME;
@@ -503,6 +504,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_STRICT_WRITES_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_X_DATADOG_TAGS_MAX_LENGTH;
 import static datadog.trace.api.config.TracerConfig.WRITER_BAGGAGE_INJECT;
 import static datadog.trace.api.config.TracerConfig.WRITER_TYPE;
+import static datadog.trace.api.config.TracerConfig.HTTP_ERROR_ENABLED;
 import static datadog.trace.api.iast.IastDetectionMode.DEFAULT;
 import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableList;
@@ -1024,6 +1026,8 @@ public class Config {
   private final String agentlessLogSubmissionUrl;
   private final String agentlessLogSubmissionProduct;
 
+  private final boolean httpErrorEnabled;
+
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
   private Config() {
     this(ConfigProvider.createDefault());
@@ -1286,6 +1290,8 @@ public class Config {
         configProvider.getIntegerRange(
             HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
 
+    httpErrorEnabled = configProvider.getBoolean(
+        HTTP_ERROR_ENABLED, DEFAULT_HTTP_ERROR_ENABLED);
     httpServerTagQueryString =
         configProvider.getBoolean(
             HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
@@ -2464,6 +2470,10 @@ public class Config {
 
   public BitSet getHttpClientErrorStatuses() {
     return httpClientErrorStatuses;
+  }
+
+  public boolean isHttpErrorEnabled() {
+    return httpErrorEnabled;
   }
 
   public boolean isHttpServerTagQueryString() {
@@ -4516,6 +4526,8 @@ public class Config {
         + httpServerErrorStatuses
         + ", httpClientErrorStatuses="
         + httpClientErrorStatuses
+        + ", httpErrorEnabled="
+        + httpErrorEnabled
         + ", httpServerTagQueryString="
         + httpServerTagQueryString
         + ", httpServerRawQueryString="


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->

通过 `-Ddd.http.error.enabled=true` 开启4xx异常状态标记
