### PR TITLE
 method file

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -67,6 +67,7 @@ public class TraceConfigInstrumentation extends InstrumenterModule {
       List<String> integrationNames = singletonList("trace-config_" + entry.getKey());
       if (InstrumenterConfig.get().isIntegrationEnabled(integrationNames, true)) {
         typeInstrumentations.add(new TracerClassInstrumentation(entry.getKey(), entry.getValue()));
+        System.out.println("Instrumenting " + entry.getKey() + " with " + entry.getValue());
       }
     }
     return typeInstrumentations;

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
@@ -107,4 +107,18 @@ public class TraceDecorator extends AsyncResultDecorator {
       return result;
     }
   }
+
+  public String getMethodName(String className) {
+    String[] packageParts = className.substring(0, className.lastIndexOf('.')).split("\\.");
+    StringBuilder abbreviatedPackageName = new StringBuilder();
+    for (String part : packageParts) {
+      if (!part.isEmpty()) {
+        abbreviatedPackageName.append(part.charAt(0)).append(".");
+      }
+    }
+    // 保留最后的类名
+    String simpleClassName = className.substring(className.lastIndexOf('.') + 1);
+    return abbreviatedPackageName + simpleClassName;
+  }
+
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -206,6 +206,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_TRACE_ANNOTATION_ASYNC = false;
   static final boolean DEFAULT_TRACE_EXECUTORS_ALL = false;
   static final String DEFAULT_TRACE_METHODS = null;
+  static final Long DEFAULT_TRACE_METHOD_FILE_LENGTH = 1024*1024L;
   static final String DEFAULT_MEASURE_METHODS = "";
   static final boolean DEFAULT_TRACE_ANALYTICS_ENABLED = false;
   static final float DEFAULT_ANALYTICS_SAMPLE_RATE = 1.0f;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -24,6 +24,7 @@ public final class TraceInstrumentationConfig {
   public static final String TRACE_EXECUTORS_ALL = "trace.executors.all";
   public static final String TRACE_EXECUTORS = "trace.executors";
   public static final String TRACE_METHODS = "trace.methods";
+  public static final String TRACE_METHODS_FILE = "trace.method.file";
   /*
   format for measure.methods is the same as for trace.methods:
   https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/java/


### PR DESCRIPTION
增强 method 埋点操作，通过指定参数`-Ddd.trace.method.file`扩展`dd.trace.methods` 配置，将需要增强的方法、类放在文件中进行维护，如下所示：

`-Ddd.trace.method.file=/home/root/agent/methods.txt `

**methods.txt** 内容格式参考如下：

```txt
com.zy.observable.server.controller.ProfilingController[*]
com.zy.observable.server.bean.AjaxResult[*]
com.zy.observable.server.controller.ServerController[auth]
com.zy.observable.server.service.TestService[*]
```

每行的书写格式参考 https://docs.datadoghq.com/tracing/trace_collection/library_config/java/ 中的 `dd.trace.methods`。

使用 `-Ddd.trace.method.file` 可以不必再配置 `dd.trace.methods`

