### PR TITLE
feat(websocket): 添加 Java-WebSocket 库的追踪支持

### DIFF
--- a/dd-java-agent/instrumentation/websocket/java-websocket/build.gradle
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/build.gradle
@@ -1,0 +1,15 @@
+muzzle {
+  pass {
+    name = "Java-WebSocket"
+    group = "org.java-websocket"
+    versions = "[1.0,)"
+  }
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+
+dependencies {
+  compileOnly group: 'org.java-websocket', name: 'Java-WebSocket', version: '1.5.3'
+}
+

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/OrgWebsocketModule.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/OrgWebsocketModule.java
@@ -1,0 +1,65 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@AutoService(InstrumenterModule.class)
+public class OrgWebsocketModule extends InstrumenterModule.Tracing {
+
+  public OrgWebsocketModule() {
+    this("java-websocket", "websocket");
+  }
+
+  protected OrgWebsocketModule(String instrumentationName, String... additionalNames) {
+    super(instrumentationName, additionalNames);
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    Map<String, String> contextStores = new HashMap<>();
+    contextStores.put("org.java_websocket.WebSocket", WebsocketAgentSpanContext.class.getName());
+    contextStores.put("org.java_websocket.client.WebSocketClient", AgentSpan.class.getName());
+    return contextStores;
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+        packageName + ".WebSocketDecorator",
+        packageName + ".WebSocketClientDecorator",
+        packageName + ".WebSocketServerDecorator",
+        packageName + ".WebsocketExtractAdapter",
+        packageName + ".TraceDraft_6455",
+        packageName + ".WebsocketHeaderInjector",
+        packageName + ".WebsocketHeaderExtract",
+        packageName + ".WebsocketAgentSpanContext",
+
+    };
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return InstrumenterConfig.get().isWebsocketTracingEnabled();
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "javax-websocket";
+  }
+
+  @Override
+  public List<Instrumenter> typeInstrumentations() {
+    return Arrays.asList(
+        new WebsocketClientInstrumentation(),
+        new WebsocketServerInstrumentation(),
+        new WebSocketSendInstrumentation()
+        );
+  }
+}

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/TraceDraft_6455.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/TraceDraft_6455.java
@@ -1,0 +1,70 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.drafts.Draft_6455;
+import org.java_websocket.extensions.IExtension;
+import org.java_websocket.protocols.IProtocol;
+
+public class TraceDraft_6455 extends  Draft_6455{
+
+  public TraceDraft_6455() {
+    super();
+  }
+
+  public TraceDraft_6455(List<IExtension> inputExtensions) {
+    super(inputExtensions);
+  }
+
+  public TraceDraft_6455(List<IExtension> inputExtensions, List<IProtocol> inputProtocols) {
+    super(inputExtensions, inputProtocols);
+  }
+
+  public TraceDraft_6455(List<IExtension> inputExtensions, List<IProtocol> inputProtocols, int maxFrameSize) {
+    super(inputExtensions, inputProtocols, maxFrameSize);
+  }
+
+  public static TraceDraft_6455 fromDraft6455(Draft_6455 original) {
+    List<IExtension> extensions = new ArrayList<>();
+    for (IExtension ext : original.getKnownExtensions()) {
+      extensions.add(ext);
+    }
+
+    List<IProtocol> protocols = new ArrayList<>();
+    for (IProtocol proto : original.getKnownProtocols()) {
+      protocols.add(proto);
+    }
+
+    return new TraceDraft_6455(
+        extensions,
+        protocols,
+        original.getMaxFrameSize()
+    );
+  }
+
+  public Draft copyInstance() {
+    ArrayList<IExtension> newExtensions = new ArrayList();
+    for(IExtension knownExtension : this.getKnownExtensions()) {
+      newExtensions.add(knownExtension.copyInstance());
+    }
+
+    ArrayList<IProtocol> newProtocols = new ArrayList();
+
+    for(IProtocol knownProtocol : this.getKnownProtocols()) {
+      newProtocols.add(knownProtocol.copyInstance());
+    }
+
+    return new TraceDraft_6455(newExtensions, newProtocols,getMaxFrameSize());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return this == o || super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+}

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebSocketClientDecorator.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebSocketClientDecorator.java
@@ -1,0 +1,49 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import static datadog.context.propagation.Propagators.defaultPropagator;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CLIENT;
+import static datadog.trace.instrumentation.websocket.org.WebsocketHeaderInjector.SETTER;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import org.java_websocket.client.WebSocketClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebSocketClientDecorator extends WebSocketDecorator {
+  private static final Logger log = LoggerFactory.getLogger(WebSocketClientDecorator.class);
+  public static final WebSocketClientDecorator CLIENT_DECORATE = new WebSocketClientDecorator();
+  @Override
+  protected CharSequence spanKind() {
+    return SPAN_KIND_CLIENT;
+  }
+
+  private static final String OPERATION_NAME = "websocket.handshake";
+
+  /**
+   * 在 connect() 调用时开始 Span
+   */
+  public AgentScope startHandshakeSpan(WebSocketClient client) {
+    // 获取 WebSocket URI
+    String uri = client.getURI().toString();
+    AgentSpan span = startSpan(OPERATION_NAME);
+    span.setTag(Tags.HTTP_URL, uri);
+    span.setTag(Tags.HTTP_METHOD, "GET"); // WebSocket 握手是 GET
+    AgentScope scope = activateSpan(span);
+    defaultPropagator().inject(scope.context(), client, SETTER);
+    afterStart(span);
+    return scope;
+  }
+
+  /**
+   * 在 onOpen 中标记握手成功并结束 Span
+   */
+  public void onHandshakeSuccess(AgentSpan span, int httpStatus) {
+    span.setTag(Tags.HTTP_STATUS, httpStatus); // 101
+    span.setTag("websocket.handshake.success", true);
+
+  }
+}

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebSocketDecorator.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebSocketDecorator.java
@@ -1,0 +1,103 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.extractContextAndGetSpanContext;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.websocket.HandlersExtractor.MESSAGE_TYPE_BINARY;
+import static datadog.trace.bootstrap.instrumentation.websocket.HandlersExtractor.MESSAGE_TYPE_TEXT;
+import static datadog.trace.instrumentation.websocket.org.WebsocketExtractAdapter.GETTER;
+
+import datadog.trace.api.DDSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import java.nio.ByteBuffer;
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.Handshakedata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class WebSocketDecorator extends BaseDecorator {
+  private static final Logger log = LoggerFactory.getLogger(WebSocketDecorator.class);
+  public static final CharSequence WEBSOCKET = UTF8BytesString.create("org-java-websocket");
+  public static final CharSequence WEBSOCKET_OPEN = UTF8BytesString.create("websocket.open");
+  public static final CharSequence WEBSOCKET_RECEIVE = UTF8BytesString.create("websocket.receive");
+  public static final CharSequence WEBSOCKET_SEND = UTF8BytesString.create("websocket.send");
+  public static final CharSequence WEBSOCKET_CLOSE = UTF8BytesString.create("websocket.close");
+  private static final String[] INSTRUMENTATION_NAMES = {WEBSOCKET.toString()};
+  private static final String REMOTE_ADDRESS = "remote.address";
+  private static final String MESSAGE_TYPE = "message.type";
+  private static final String MESSAGE_SIZE = "message.size";
+  private static final String MESSAGE_REMOTE = "message.remote";
+  private static final String MESSAGE_CODE = "message.code";
+  private static final String MESSAGE_REASON = "message.reason";
+
+  @Override
+  protected String[] instrumentationNames() {
+    return INSTRUMENTATION_NAMES;
+  }
+
+  @Override
+  protected CharSequence spanType() {
+    return DDSpanTypes.WEBSOCKET;
+  }
+
+  @Override
+  protected CharSequence component() {
+    return WEBSOCKET;
+  }
+  protected abstract CharSequence spanKind();
+
+  public AgentSpan open(WebSocket conn, Handshakedata handshake) {
+    
+    AgentSpanContext parentContext = extractContextAndGetSpanContext(handshake, GETTER);
+    AgentSpan span = startSpan(instrumentationNames()[0],WEBSOCKET_OPEN,parentContext);
+    span.setTag(REMOTE_ADDRESS, conn.getRemoteSocketAddress().toString());
+    afterStart(span);
+    return span;
+  }
+
+  public AgentSpan onMessage(Object message,AgentSpanContext spanContext) {
+    AgentSpan span =  startSpan(instrumentationNames()[0],WEBSOCKET_RECEIVE,spanContext);
+    CharSequence messageType;
+    int msgSize;
+    if(message instanceof ByteBuffer){
+      messageType = MESSAGE_TYPE_BINARY;
+      msgSize = ((ByteBuffer) message).remaining();
+    }else{
+      messageType = MESSAGE_TYPE_TEXT;
+      msgSize = ((String) message).length();
+    }
+    span.setTag(MESSAGE_SIZE, msgSize);
+    span.setTag(MESSAGE_TYPE, messageType);
+    afterStart(span);
+    return span;
+  }
+
+  public AgentSpan send(WebsocketAgentSpanContext spanContext) {
+    AgentSpan span;
+    if(spanContext==null){
+      span =  startSpan(instrumentationNames()[0],WEBSOCKET_SEND);
+    }else{
+      span =  startSpan(instrumentationNames()[0],WEBSOCKET_SEND,spanContext.getSpanContext());
+      span.setTag(Tags.SPAN_KIND, spanContext.getSpanKind());
+    }
+    return span;
+  }
+
+  public AgentSpan onClose(int code, String reason, boolean remote,AgentSpanContext spanContext) {
+    AgentSpan span =  startSpan(instrumentationNames()[0],WEBSOCKET_CLOSE,spanContext);
+    span.setTag(MESSAGE_REASON, reason);
+    span.setTag(MESSAGE_CODE, code);
+    span.setTag(MESSAGE_REMOTE, remote);
+    afterStart(span);
+    return span;
+  }
+
+  @Override
+  public AgentSpan afterStart(AgentSpan span) {
+    span.setTag(Tags.SPAN_KIND, spanKind());
+    return super.afterStart(span);
+  }
+}

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebSocketSendInstrumentation.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebSocketSendInstrumentation.java
@@ -1,0 +1,87 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
+import static datadog.trace.instrumentation.websocket.org.WebSocketServerDecorator.SERVER_DECORATOR;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPrivate;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.Collection;
+import net.bytebuddy.asm.Advice;
+import org.java_websocket.WebSocket;
+import org.java_websocket.WebSocketImpl;
+import org.java_websocket.framing.CloseFrame;
+import org.java_websocket.framing.Framedata;
+import org.java_websocket.framing.PingFrame;
+import org.java_websocket.framing.PongFrame;
+
+
+public class WebSocketSendInstrumentation implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public WebSocketSendInstrumentation() {
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.java_websocket.WebSocketImpl";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod()
+            .and(isPrivate())
+            .and(named("send"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, Collection.class))
+        ,
+        getClass().getName() + "$OnSendAdvice");
+  }
+
+
+  public static class OnSendAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope onEnter(
+        @Advice.This WebSocketImpl impl,
+        @Advice.Argument(value = 0) Collection<Framedata> frames) {
+      WebsocketAgentSpanContext context = InstrumentationContext.get(WebSocket.class, WebsocketAgentSpanContext.class).get(impl);
+      if (context == null) {
+        // close after send
+        final AgentSpan wsSpan =
+            SERVER_DECORATOR.send(null);
+        return activateSpan(wsSpan);
+      }
+      // ignore ping/pong/close
+      for (Framedata frame : frames) {
+        if (frame instanceof PingFrame || frame instanceof PongFrame || frame instanceof CloseFrame){
+          return activateSpan(noopSpan());
+        }
+      }
+      final AgentSpan wsSpan =
+          SERVER_DECORATOR.send(context);
+      return activateSpan(wsSpan);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    public static void onExit(
+        @Advice.Enter final AgentScope scope,
+        @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      SERVER_DECORATOR.onError(scope.span(), throwable);
+      SERVER_DECORATOR.beforeFinish(scope.span());
+      scope.close();
+      scope.span().finish();
+    }
+  }
+
+
+}

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebSocketServerDecorator.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebSocketServerDecorator.java
@@ -1,0 +1,12 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER;
+
+public class WebSocketServerDecorator extends WebSocketDecorator {
+  public static final WebSocketServerDecorator SERVER_DECORATOR = new WebSocketServerDecorator();
+
+  @Override
+  protected CharSequence spanKind() {
+    return SPAN_KIND_SERVER;
+  }
+}

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketAgentSpanContext.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketAgentSpanContext.java
@@ -1,0 +1,23 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
+
+public class WebsocketAgentSpanContext {
+  private AgentSpanContext spanContext;
+  private String spanKind;
+
+  public WebsocketAgentSpanContext(AgentSpanContext spanContext,Object spanKindObj) {
+    this.spanContext = spanContext;
+    if (spanKindObj != null) {
+      this.spanKind = spanKindObj.toString();
+    }
+  }
+
+  public AgentSpanContext getSpanContext() {
+    return spanContext;
+  }
+
+  public String getSpanKind() {
+    return spanKind;
+  }
+}

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketClientInstrumentation.java
@@ -1,0 +1,276 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
+import static datadog.trace.instrumentation.websocket.org.WebSocketClientDecorator.CLIENT_DECORATE;
+import static datadog.trace.instrumentation.websocket.org.WebSocketDecorator.WEBSOCKET_CLOSE;
+import static datadog.trace.instrumentation.websocket.org.WebSocketDecorator.WEBSOCKET_OPEN;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.java_websocket.WebSocket;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.drafts.Draft_6455;
+import org.java_websocket.handshake.Handshakedata;
+import org.java_websocket.handshake.ServerHandshake;
+
+public class WebsocketClientInstrumentation implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
+
+  public WebsocketClientInstrumentation() {
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "org.java_websocket.client.WebSocketClient";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return extendsClass(named(hierarchyMarkerType()));
+  }
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod()
+            .and(isPublic())
+            .and(nameStartsWith("onWebsocketOpen"))
+            .and(takesArguments(2))
+        ,
+        getClass().getName() + "$OnOpenAdvice");
+
+    transformer.applyAdvice(
+        isConstructor().and(takesArguments(4)),
+        getClass().getName() + "$ClientConstructorAdvice");
+
+    transformer.applyAdvice(
+        isMethod()
+            .and(isPublic())
+            .and(named("connect"))
+            .and(takesArguments(0))
+        ,
+        getClass().getName() + "$ConnectAdvice");
+
+    transformer.applyAdvice(
+        isMethod()
+            .and(isPublic())
+            .and(nameStartsWith("onWebsocketMessage"))
+            .and(takesArguments(2))
+        ,
+        getClass().getName() + "$OnMessageAdvice");
+
+    transformer.applyAdvice(
+        isMethod()
+            .and(isPublic())
+            .and(nameStartsWith("onWebsocketClose"))
+            .and(takesArguments(4))
+        ,
+        getClass().getName() + "$OnCloseAdvice");
+
+    transformer.applyAdvice(
+        isMethod()
+            .and(isPublic())
+            .and(named("onWebsocketError"))
+            .and(takesArguments(2))
+        ,
+        getClass().getName() + "$ErrorAdvice");
+
+
+  }
+
+  public static class ConnectAdvice{
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope onEnter(
+        @Advice.This WebSocketClient client) {
+
+      // 防止嵌套调用（如果 connect 内部调用了重载方法）
+      int callDepth = CallDepthThreadLocalMap.incrementCallDepth(WebSocketClient.class);
+      if (callDepth > 0) {
+        return null;
+      }
+      // 创建握手 Span
+      AgentScope scope = CLIENT_DECORATE.startHandshakeSpan(client);
+      InstrumentationContext.get(WebSocketClient.class, AgentSpan.class).put(client, scope.span());
+      return scope;
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    public static void onExit(
+        @Advice.Enter AgentScope scope,
+        @Advice.Thrown Throwable throwable) {
+
+      CallDepthThreadLocalMap.decrementCallDepth(WebSocketClient.class);
+      if (scope == null) {
+        return;
+      }
+      // // 如果 connect() 抛出异常（同步失败），立即结束 span
+      if (throwable != null) {
+        AgentSpan span = scope.span();
+        CLIENT_DECORATE.onError(scope.span(), throwable);
+        CLIENT_DECORATE.beforeFinish(scope.span());
+
+        scope.close();
+        scope.span().finish();
+      }
+      System.out.println("exit...............");
+      // 不要在这里关闭 scope，因为握手是异步的，onOpen 时才结束
+      // scope.close() 应该在 onOpen 或 onError 中调用
+    }
+  }
+
+  public static class ClientConstructorAdvice{
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.Argument(value = 1,readOnly = false) Draft protocolDraft) {
+      if(protocolDraft==null){
+        return;
+      }
+      if (protocolDraft instanceof Draft_6455 && !(protocolDraft instanceof TraceDraft_6455)){
+        try {
+          // 创建 tracing wrapper
+          protocolDraft = TraceDraft_6455.fromDraft6455((Draft_6455) protocolDraft);
+        } catch (Exception e) {
+          // 如果包装失败，继续使用原始 draft（fail-safe）
+        }
+      }
+    }
+  }
+
+  public static class OnOpenAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope onEnter(
+        @Advice.Argument(value = 0) WebSocket conn,
+        @Advice.Argument(value = 1) Handshakedata handshake, @Advice.This WebSocketClient client) {
+      // 从 context 中获取之前创建的 span
+      AgentSpan span = InstrumentationContext.get(WebSocketClient.class, AgentSpan.class).get(client);
+      System.out.println("open...............");
+      if (span == null) {
+        return noopScope();
+      }
+      span.setOperationName(WEBSOCKET_OPEN);
+      CLIENT_DECORATE.onHandshakeSuccess(span, ((ServerHandshake)handshake).getHttpStatus());
+      // 清理 context
+      InstrumentationContext.get(WebSocketClient.class, AgentSpan.class).remove(client);
+      WebsocketAgentSpanContext spanContext = new WebsocketAgentSpanContext(span.context(),span.getTag(Tags.SPAN_KIND));
+      // defaultPropagator().inject(span, headers, SETTER);
+      InstrumentationContext.get(WebSocket.class, WebsocketAgentSpanContext.class).put(conn,spanContext);
+      return activateSpan(span);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    public static void onExit(
+        @Advice.Enter final AgentScope scope,
+        @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      CLIENT_DECORATE.onError(scope.span(), throwable);
+      CLIENT_DECORATE.beforeFinish(scope.span());
+
+      scope.close();
+      scope.span().finish();
+    }
+  }
+
+  public static class OnMessageAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope onEnter(
+        @Advice.Argument(value = 0) WebSocket engine,
+        @Advice.Argument(value = 1) Object message ) {
+      System.out.println("message...............");
+      WebsocketAgentSpanContext context = InstrumentationContext.get(WebSocket.class, WebsocketAgentSpanContext.class).get(engine);
+      if (context == null) {
+        return activateSpan(noopSpan());
+      }
+      final AgentSpan wsSpan =
+          CLIENT_DECORATE.onMessage(message,context.getSpanContext());
+      return activateSpan(wsSpan);
+    }
+
+      @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+      public static void onExit(
+          @Advice.Enter final AgentScope scope,
+          @Advice.Thrown final Throwable throwable) {
+        if (scope == null) {
+          return;
+        }
+        CLIENT_DECORATE.onError(scope.span(), throwable);
+        CLIENT_DECORATE.beforeFinish(scope.span());
+
+        scope.close();
+        scope.span().finish();
+      }
+    }
+
+  public static class OnCloseAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope onEnter(
+        @Advice.This WebSocketClient client,
+        @Advice.Argument(value = 0) WebSocket conn,
+        @Advice.Argument(value = 1) int code,
+        @Advice.Argument(value = 2) String message,
+        @Advice.Argument(value = 3) boolean remote) {
+      System.out.println("close...............");
+      WebsocketAgentSpanContext context = InstrumentationContext.get(WebSocket.class, WebsocketAgentSpanContext.class).get(conn);
+      if (context == null) {
+        AgentSpan agentSpan = InstrumentationContext.get(WebSocketClient.class, AgentSpan.class).get(client);
+        if (agentSpan != null){
+          agentSpan.setOperationName(WEBSOCKET_CLOSE);
+          InstrumentationContext.get(WebSocketClient.class, AgentSpan.class).remove(client);
+          return activateSpan(agentSpan);
+        }
+        return activateSpan(noopSpan());
+      }
+
+      final AgentSpan wsSpan =
+          CLIENT_DECORATE.onClose(code,message,remote,context.getSpanContext());
+      InstrumentationContext.get(WebSocket.class, WebsocketAgentSpanContext.class).remove(conn);
+      return activateSpan(wsSpan);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    public static void onExit(
+        @Advice.Enter final AgentScope scope,
+        @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      CLIENT_DECORATE.onError(scope.span(), throwable);
+      CLIENT_DECORATE.beforeFinish(scope.span());
+      scope.close();
+      scope.span().finish();
+    }
+  }
+
+
+  public static class ErrorAdvice {
+    @Advice.OnMethodExit
+    public static void onExit(
+        @Advice.This WebSocketClient client,
+        @Advice.Argument(value = 0) WebSocket conn,
+        @Advice.Argument(value = 1) Exception ex) {
+        AgentSpan agentSpan = InstrumentationContext.get(WebSocketClient.class, AgentSpan.class).get(client);
+        if (agentSpan == null){
+          return;
+        }
+      System.out.println("onerror...............");
+      CLIENT_DECORATE.onError(agentSpan, ex);
+      // InstrumentationContext.get(WebSocketClient.class, AgentSpan.class).put(client,agentSpan);
+    }
+  }
+
+}

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketExtractAdapter.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketExtractAdapter.java
@@ -1,0 +1,28 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import java.util.Iterator;
+import org.java_websocket.handshake.Handshakedata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebsocketExtractAdapter implements AgentPropagation.ContextVisitor<Handshakedata>{
+  public static final WebsocketExtractAdapter GETTER = new WebsocketExtractAdapter();
+  private static final Logger log = LoggerFactory.getLogger(WebsocketExtractAdapter.class);
+  @Override
+  public void forEachKey(Handshakedata carrier, AgentPropagation.KeyClassifier classifier) {
+    Iterator<String> iterator = carrier.iterateHttpFields();
+    while(iterator.hasNext()){
+      String key = iterator.next();
+      String value = carrier.getFieldValue(key);
+      if (log.isDebugEnabled()) {
+        log.info("websocket ==== key:{},value:{}", key, value);
+      }
+      if (null != value) {
+        if (!classifier.accept(key, value)) {
+          return;
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketHeaderExtract.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketHeaderExtract.java
@@ -1,0 +1,19 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebsocketHeaderExtract implements AgentPropagation.ContextVisitor<Map<String, String>>{
+  public static final WebsocketHeaderExtract HEADER_GETTER = new WebsocketHeaderExtract();
+  private static final Logger log = LoggerFactory.getLogger(WebsocketHeaderExtract.class);
+  @Override
+  public void forEachKey(Map<String, String> carrier, AgentPropagation.KeyClassifier classifier) {
+    for (Map.Entry<String, String> entry : carrier.entrySet()){
+      if (!classifier.accept(entry.getKey(), entry.getValue())) {
+        return;
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketHeaderInjector.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketHeaderInjector.java
@@ -1,0 +1,16 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import datadog.context.propagation.CarrierSetter;
+import org.java_websocket.client.WebSocketClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebsocketHeaderInjector implements CarrierSetter<WebSocketClient> {
+  public static final WebsocketHeaderInjector SETTER = new WebsocketHeaderInjector();
+  private static final Logger log = LoggerFactory.getLogger(WebsocketHeaderInjector.class);
+
+  @Override
+  public void set(WebSocketClient carrier, String key, String value) {
+    carrier.addHeader(key, value);
+  }
+}

--- a/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/websocket/java-websocket/src/main/java/datadog/trace/instrumentation/websocket/org/WebsocketServerInstrumentation.java
@@ -1,0 +1,153 @@
+package datadog.trace.instrumentation.websocket.org;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
+import static datadog.trace.instrumentation.websocket.org.WebSocketServerDecorator.SERVER_DECORATOR;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.Handshakedata;
+
+public class WebsocketServerInstrumentation implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
+
+  public WebsocketServerInstrumentation() {
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "org.java_websocket.server.WebSocketServer";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return extendsClass(named(hierarchyMarkerType()));
+  }
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod()
+            .and(isPublic())
+            .and(nameStartsWith("onWebsocketOpen"))
+            .and(takesArguments(2))
+        ,
+        getClass().getName() + "$OnOpenAdvice");
+    transformer.applyAdvice(
+        isMethod()
+            .and(isPublic())
+            .and(nameStartsWith("onMessage"))
+            .and(takesArguments(2))
+        ,
+        getClass().getName() + "$OnMessageAdvice");
+    transformer.applyAdvice(
+        isMethod()
+            .and(isPublic())
+            .and(nameStartsWith("onClose"))
+            .and(takesArguments(4))
+        ,
+        getClass().getName() + "$OnCloseAdvice");
+  }
+
+
+  public static class OnOpenAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope onEnter(
+        @Advice.Argument(value = 0) WebSocket conn,
+        @Advice.Argument(value = 1) Handshakedata handshake) {
+      AgentSpan span = SERVER_DECORATOR.open(conn, handshake);
+      WebsocketAgentSpanContext spanContext = new WebsocketAgentSpanContext(span.context(),span.getTag(Tags.SPAN_KIND));
+      InstrumentationContext.get(WebSocket.class, WebsocketAgentSpanContext.class).put(conn,spanContext);
+      return activateSpan(span);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    public static void onExit(
+        @Advice.Enter final AgentScope scope,
+        @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      SERVER_DECORATOR.onError(scope.span(), throwable);
+      SERVER_DECORATOR.beforeFinish(scope.span());
+
+      scope.close();
+      scope.span().finish();
+    }
+  }
+
+  public static class OnMessageAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope onEnter(
+        @Advice.Argument(value = 0) WebSocket conn,
+        @Advice.Argument(value = 1) Object message ) {
+      WebsocketAgentSpanContext context = InstrumentationContext.get(WebSocket.class, WebsocketAgentSpanContext.class).get(conn);
+      if (context == null) {
+        return activateSpan(noopSpan());
+      }
+      AgentSpanContext spanContext = context.getSpanContext();
+      final AgentSpan wsSpan =
+          SERVER_DECORATOR.onMessage(message,spanContext);
+      return activateSpan(wsSpan);
+    }
+
+      @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+      public static void onExit(
+          @Advice.Enter final AgentScope scope,
+          @Advice.Thrown final Throwable throwable) {
+        if (scope == null) {
+          return;
+        }
+        SERVER_DECORATOR.onError(scope.span(), throwable);
+        SERVER_DECORATOR.beforeFinish(scope.span());
+
+        scope.close();
+        scope.span().finish();
+      }
+    }
+
+  public static class OnCloseAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope onEnter(
+        @Advice.Argument(value = 0) WebSocket conn,
+        @Advice.Argument(value = 1) int code,
+        @Advice.Argument(value = 2) String message,
+        @Advice.Argument(value = 3) boolean remote) {
+      WebsocketAgentSpanContext context = InstrumentationContext.get(WebSocket.class, WebsocketAgentSpanContext.class).get(conn);
+      if (context == null) {
+        return activateSpan(noopSpan());
+      }
+      AgentSpanContext spanContext = context.getSpanContext();
+      final AgentSpan wsSpan =
+          SERVER_DECORATOR.onClose(code,message,remote,spanContext);
+      InstrumentationContext.get(WebSocket.class, WebsocketAgentSpanContext.class).remove(conn);
+      return activateSpan(wsSpan);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    public static void onExit(
+        @Advice.Enter final AgentScope scope,
+        @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      SERVER_DECORATOR.onError(scope.span(), throwable);
+      SERVER_DECORATOR.beforeFinish(scope.span());
+      scope.close();
+      scope.span().finish();
+    }
+  }
+
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -111,7 +111,7 @@ public final class ConfigDefaults {
   // value to false if config is under breaking changes flag
   static final boolean DEFAULT_LOGS_INJECTION_ENABLED = true;
 
-  static final String DEFAULT_APPSEC_ENABLED = "inactive";
+  static final String DEFAULT_APPSEC_ENABLED = "false";
   static final boolean DEFAULT_APPSEC_REPORTING_INBAND = false;
   static final int DEFAULT_APPSEC_TRACE_RATE_LIMIT = 100;
   static final boolean DEFAULT_APPSEC_WAF_METRICS = true;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -623,6 +623,7 @@ include(
   ":dd-java-agent:instrumentation:redisson:redisson-3.10.3",
   ":dd-java-agent:instrumentation:weaver",
   ":dd-java-agent:instrumentation:websocket:jakarta-websocket-2.0",
+  ":dd-java-agent:instrumentation:websocket:java-websocket",
   ":dd-java-agent:instrumentation:websocket:javax-websocket-1.0",
   ":dd-java-agent:instrumentation:websocket:jetty-websocket",
   ":dd-java-agent:instrumentation:websocket:jetty-websocket:jetty-websocket-10",


### PR DESCRIPTION
- 新增 java-websocket 模块用于追踪 WebSocket 连接、消息发送接收和关闭事件
- 实现 WebSocket 客户端和服务器端的装饰器类进行操作追踪
- 添加握手、消息传输和连接状态变更的分布式追踪支持
- 集成 TraceDraft_6455 类以支持 WebSocket 协议草案的追踪
- 创建 WebsocketAgentSpanContext 管理 WebSocket 连接的追踪上下文
- 实现 WebSocket 消息类型和大小的标签记录功能
- 添加 WebSocket 错误处理和异常追踪机制
- 注册新的 instrumentation 模块到主配置中
- 默认关闭 websocket 链路追踪，如需开启，需要使用参数 `-Ddd.trace.websocket.messages.enabled=true`
# What Does This Do

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, move, or deletion
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
