### PR TITLE
Fix SQS v1 distributed trace propagation

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/messaging/DatadogAttributeParser.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/messaging/DatadogAttributeParser.java
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap.instrumentation.messaging;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import datadog.trace.api.DDTraceId;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import java.nio.ByteBuffer;
@@ -21,9 +22,10 @@ public final class DatadogAttributeParser {
       return;
     }
     try {
-      if (acceptJsonProperty(classifier, json, "x-datadog-trace-id")) {
+      if (acceptTraceIdProperty(classifier, json)) {
         acceptJsonProperty(classifier, json, "x-datadog-parent-id");
         acceptJsonProperty(classifier, json, "x-datadog-sampling-priority");
+        acceptJsonProperty(classifier, json, "x-datadog-tags");
       }
       if (Config.get().isDataStreamsEnabled()) {
         acceptJsonProperty(classifier, json, "dd-pathway-ctx-base64");
@@ -73,5 +75,39 @@ public final class DatadogAttributeParser {
       }
     }
     return false;
+  }
+
+  private static boolean acceptTraceIdProperty(
+      AgentPropagation.KeyClassifier classifier, String json) {
+    int keyStart = json.indexOf("x-datadog-trace-id");
+    if (keyStart > 0) {
+      int separator = json.indexOf(':', keyStart + "x-datadog-trace-id".length());
+      if (separator > 0) {
+        int valueStart = json.indexOf('"', separator + 1);
+        if (valueStart > 0) {
+          int valueEnd = json.indexOf('"', valueStart + 1);
+          if (valueEnd > 0) {
+            String traceId = json.substring(valueStart + 1, valueEnd);
+            return classifier.accept(
+                "x-datadog-trace-id", normalizeTraceIdForDatadogExtraction(traceId));
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  private static String normalizeTraceIdForDatadogExtraction(String traceId) {
+    try {
+      DDTraceId parsed = DDTraceId.from(traceId);
+      return Long.toUnsignedString(parsed.toLong());
+    } catch (NumberFormatException ignored) {
+    }
+    try {
+      DDTraceId parsed = DDTraceId.fromHex(traceId);
+      return Long.toUnsignedString(parsed.toLong());
+    } catch (NumberFormatException ignored) {
+    }
+    return traceId;
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/messaging/DatadogAttributeParserTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/messaging/DatadogAttributeParserTest.groovy
@@ -1,0 +1,24 @@
+package datadog.trace.bootstrap.instrumentation.messaging
+
+import datadog.trace.test.util.DDSpecification
+
+class DatadogAttributeParserTest extends DDSpecification {
+
+  def "normalizes hex trace id and keeps propagation tags"() {
+    setup:
+    def extracted = [:]
+    def json = '{"x-datadog-trace-id":"69c0b39f000000002bd8d3176581bf4f","x-datadog-parent-id":"2585836967003721736","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.dm=-1,_dd.p.tid=69c0b39f00000000"}'
+
+    when:
+    DatadogAttributeParser.forEachProperty({ key, value ->
+      extracted[key] = value
+      true
+    }, json)
+
+    then:
+    extracted["x-datadog-trace-id"] == "3159507236041113423"
+    extracted["x-datadog-parent-id"] == "2585836967003721736"
+    extracted["x-datadog-sampling-priority"] == "1"
+    extracted["x-datadog-tags"] == "_dd.p.dm=-1,_dd.p.tid=69c0b39f00000000"
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/MessageAttributeInjector.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/MessageAttributeInjector.java
@@ -1,26 +1,13 @@
 package datadog.trace.instrumentation.aws.v1.sqs;
 
-import static datadog.trace.api.datastreams.PathwayContext.DATADOG_KEY;
-
-import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import datadog.context.propagation.CarrierSetter;
-import datadog.trace.api.Config;
-import java.util.Map;
 
-public class MessageAttributeInjector implements CarrierSetter<Map<String, MessageAttributeValue>> {
+public class MessageAttributeInjector implements CarrierSetter<StringBuilder> {
 
   public static final MessageAttributeInjector SETTER = new MessageAttributeInjector();
 
   @Override
-  public void set(
-      final Map<String, MessageAttributeValue> carrier, final String key, final String value) {
-    if (carrier.size() < 10
-        && !carrier.containsKey(DATADOG_KEY)
-        && Config.get().isSqsInjectDatadogAttributeEnabled()) {
-      String jsonPathway = String.format("{\"%s\": \"%s\"}", key, value);
-      carrier.put(
-          DATADOG_KEY,
-          new MessageAttributeValue().withDataType("String").withStringValue(jsonPathway));
-    }
+  public void set(final StringBuilder builder, final String key, final String value) {
+    builder.append('\"').append(key).append("\":\"").append(value).append("\",");
   }
 }

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsClientInstrumentation.java
@@ -52,17 +52,19 @@ public final class SqsClientInstrumentation extends InstrumenterModule.Tracing
   public static class HandlerChainAdvice {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void addHandler(@Advice.Return final List<RequestHandler2> handlers) {
-      if (Config.get().isDataStreamsEnabled()) {
-        for (RequestHandler2 interceptor : handlers) {
-          if (interceptor instanceof SqsInterceptor) {
-            return; // list already has our interceptor, return to builder
-          }
-        }
-        handlers.add(
-            new SqsInterceptor(
-                InstrumentationContext.get(
-                    "com.amazonaws.AmazonWebServiceRequest", "datadog.context.Context")));
+      if (!Config.get().isDataStreamsEnabled()
+          && !Config.get().isSqsInjectDatadogAttributeEnabled()) {
+        return;
       }
+      for (RequestHandler2 interceptor : handlers) {
+        if (interceptor instanceof SqsInterceptor) {
+          return; // list already has our interceptor, return to builder
+        }
+      }
+      handlers.add(
+          new SqsInterceptor(
+              InstrumentationContext.get(
+                  "com.amazonaws.AmazonWebServiceRequest", "datadog.context.Context")));
     }
   }
 }

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsInterceptor.java
@@ -1,10 +1,11 @@
 package datadog.trace.instrumentation.aws.v1.sqs;
 
+import static datadog.context.propagation.Propagators.defaultPropagator;
 import static datadog.trace.api.datastreams.DataStreamsTags.Direction.OUTBOUND;
 import static datadog.trace.api.datastreams.DataStreamsTags.create;
 import static datadog.trace.api.datastreams.PathwayContext.DATADOG_KEY;
-import static datadog.trace.bootstrap.instrumentation.api.AgentPropagation.DSM_CONCERN;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.bootstrap.instrumentation.api.URIUtils.urlFileName;
 import static datadog.trace.instrumentation.aws.v1.sqs.MessageAttributeInjector.SETTER;
 
@@ -16,8 +17,6 @@ import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import datadog.context.Context;
-import datadog.context.propagation.Propagator;
-import datadog.context.propagation.Propagators;
 import datadog.trace.api.Config;
 import datadog.trace.api.datastreams.DataStreamsContext;
 import datadog.trace.api.datastreams.DataStreamsTags;
@@ -43,14 +42,15 @@ public class SqsInterceptor extends RequestHandler2 {
 
       String queueUrl = smRequest.getQueueUrl();
       if (queueUrl == null) return request;
+      if (!Config.get().isSqsInjectDatadogAttributeEnabled()) {
+        return request;
+      }
 
-      Propagator dsmPropagator = Propagators.forConcern(DSM_CONCERN);
-      Context context = newContext(request, queueUrl);
       // making a copy of the MessageAttributes before modifying them because they can be stored in
       // a kind of ImmutableMap
       Map<String, MessageAttributeValue> messageAttributes =
           new HashMap<>(smRequest.getMessageAttributes());
-      dsmPropagator.inject(context, messageAttributes, SETTER);
+      injectTraceContext(messageAttributes, request, queueUrl);
       // note: modifying message attributes has to be done before marshalling, otherwise the changes
       // are not reflected in the actual request (and the MD5 check on send will fail).
       smRequest.setMessageAttributes(messageAttributes);
@@ -59,13 +59,14 @@ public class SqsInterceptor extends RequestHandler2 {
 
       String queueUrl = smbRequest.getQueueUrl();
       if (queueUrl == null) return request;
+      if (!Config.get().isSqsInjectDatadogAttributeEnabled()) {
+        return request;
+      }
 
-      Propagator dsmPropagator = Propagators.forConcern(DSM_CONCERN);
-      Context context = newContext(request, queueUrl);
       for (SendMessageBatchRequestEntry entry : smbRequest.getEntries()) {
         Map<String, MessageAttributeValue> messageAttributes =
             new HashMap<>(entry.getMessageAttributes());
-        dsmPropagator.inject(context, messageAttributes, SETTER);
+        injectTraceContext(messageAttributes, request, queueUrl);
         entry.setMessageAttributes(messageAttributes);
       }
     } else if (request instanceof ReceiveMessageRequest) {
@@ -81,10 +82,37 @@ public class SqsInterceptor extends RequestHandler2 {
     return request;
   }
 
+  private void injectTraceContext(
+      Map<String, MessageAttributeValue> messageAttributes,
+      AmazonWebServiceRequest request,
+      String queueUrl) {
+    if (messageAttributes.size() >= 10 || messageAttributes.containsKey(DATADOG_KEY)) {
+      return;
+    }
+
+    StringBuilder jsonBuilder = new StringBuilder();
+    jsonBuilder.append('{');
+    defaultPropagator().inject(newContext(request, queueUrl), jsonBuilder, SETTER);
+    if (jsonBuilder.length() == 1) {
+      return;
+    }
+    jsonBuilder.setLength(jsonBuilder.length() - 1);
+    jsonBuilder.append('}');
+    messageAttributes.put(
+        DATADOG_KEY,
+        new MessageAttributeValue()
+            .withDataType("String")
+            .withStringValue(jsonBuilder.toString()));
+  }
+
   private Context newContext(AmazonWebServiceRequest request, String queueUrl) {
     AgentSpan span = newSpan(request);
-    DataStreamsContext dsmContext = DataStreamsContext.fromTags(getTags(queueUrl));
-    return span.with(dsmContext);
+    Context context = span;
+    if (traceConfig().isDataStreamsEnabled()) {
+      DataStreamsContext dsmContext = DataStreamsContext.fromTags(getTags(queueUrl));
+      context = context.with(dsmContext);
+    }
+    return context;
   }
 
   private AgentSpan newSpan(AmazonWebServiceRequest request) {

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveRequestInstrumentation.java
@@ -9,6 +9,9 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.api.Config;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import net.bytebuddy.asm.Advice;
 
@@ -24,23 +27,68 @@ public class SqsReceiveRequestInstrumentation extends AbstractSqsInstrumentation
   @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
-        isConstructor().or(isMethod().and(namedOneOf("setAttributeNames", "withAttributeNames"))),
+        isConstructor()
+            .or(
+                isMethod()
+                    .and(
+                        namedOneOf(
+                            "setAttributeNames",
+                            "withAttributeNames",
+                            "setMessageSystemAttributeNames",
+                            "withMessageSystemAttributeNames"))),
         getClass().getName() + "$ReceiveMessageRequestAdvice");
   }
 
   public static class ReceiveMessageRequestAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.This ReceiveMessageRequest request) {
-      if (Config.get().isSqsPropagationEnabled()) {
-        // ReceiveMessageRequest always returns a mutable list which we can append to
-        List<String> attributeNames = request.getAttributeNames();
-        for (String name : attributeNames) {
-          if ("AWSTraceHeader".equals(name) || "All".equals(name)) {
-            return;
-          }
-        }
-        attributeNames.add("AWSTraceHeader");
+      if (!Config.get().isSqsPropagationEnabled()) {
+        return;
       }
+
+      if (addMessageSystemAttribute(request)) {
+        return;
+      }
+
+      // Older SDKs only expose attributeNames and keep the returned list mutable.
+      List<String> attributeNames = request.getAttributeNames();
+      if (containsTraceHeader(attributeNames)) {
+        return;
+      }
+      attributeNames.add("AWSTraceHeader");
+    }
+
+    private static boolean addMessageSystemAttribute(ReceiveMessageRequest request) {
+      try {
+        Method getter = request.getClass().getMethod("getMessageSystemAttributeNames");
+        List<String> attributeNames = (List<String>) getter.invoke(request);
+        if (containsTraceHeader(attributeNames)) {
+          return true;
+        }
+        try {
+          attributeNames.add("AWSTraceHeader");
+        } catch (UnsupportedOperationException ignored) {
+          List<String> updatedAttributeNames = new ArrayList<>(attributeNames);
+          updatedAttributeNames.add("AWSTraceHeader");
+          Method setter =
+              request
+                  .getClass()
+                  .getMethod("setMessageSystemAttributeNames", Collection.class);
+          setter.invoke(request, updatedAttributeNames);
+        }
+        return true;
+      } catch (ReflectiveOperationException ignored) {
+        return false;
+      }
+    }
+
+    private static boolean containsTraceHeader(List<String> attributeNames) {
+      for (String name : attributeNames) {
+        if ("AWSTraceHeader".equals(name) || "All".equals(name)) {
+          return true;
+        }
+      }
+      return false;
     }
   }
 }

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
@@ -214,6 +214,19 @@ abstract class SqsClientTest extends VersionedNamingTestBase {
     client.shutdown()
   }
 
+  @IgnoreIf({ !instance.isLatestDepTest })
+  def "AWSTraceHeader is requested as a message system attribute on latest aws sdk v1"() {
+    setup:
+    def request = new ReceiveMessageRequest("http://localhost:${address.port}/000000000000/somequeue")
+
+    when:
+    request.withMessageSystemAttributeNames("SenderId")
+
+    then:
+    request.getMessageSystemAttributeNames().contains("SenderId")
+    request.getMessageSystemAttributeNames().contains("AWSTraceHeader")
+  }
+
   @IgnoreIf({ !instance.isDataStreamsEnabled() })
   def "propagation even when message attributes are readonly"() {
     setup:
@@ -725,5 +738,3 @@ class SqsClientV1DataStreamsForkedTest extends SqsClientTest {
     client.shutdown()
   }
 }
-
-


### PR DESCRIPTION

  Description

  ## Summary

  This PR fixes distributed trace propagation for AWS SQS SDK v1, including recent 1.12.x releases.

  Previously, SQS v1 could inject _datadog attributes on send in some cases, but receive-side trace extraction still failed in practice. The main issue was that the embedded Datadog trace ID could be stored in 128-bit
  hex form, while the default Datadog extractor expected a decimal trace ID. As a result, the consumer span started a new trace instead of continuing the producer trace.

  This change makes SQS v1 send/receive propagation work end-to-end.

  ## What changed

  - Enabled the SQS v1 interceptor whenever SQS Datadog attribute injection is enabled, not only when Data Streams Monitoring is enabled.
  - Switched SQS v1 send-side _datadog injection to use the default propagator so full Datadog trace context is embedded.
  - Kept DSM context injection when DSM is enabled.
  - Added compatibility for newer AWS SDK v1 ReceiveMessageRequest APIs that use messageSystemAttributeNames instead of only attributeNames.
  - Fixed embedded _datadog parsing so 128-bit hex trace IDs are normalized for Datadog extraction and propagation tags are preserved.

  ## Why this is needed

  With AWS SDK v1, messages could contain both:

  - _datadog
  - AWSTraceHeader

  However, default extraction does not rely on X-Ray by default, and the Datadog extractor could not correctly consume the hex trace ID stored in _datadog. That caused receive spans to start a fresh trace even though
  propagation metadata was present on the message.

  ## Validation

  Validated with:

  ./gradlew :dd-java-agent:agent-bootstrap:compileTestGroovy \
    :dd-java-agent:instrumentation:aws-java:aws-java-sqs-1.0:compileJava \
    :dd-java-agent:instrumentation:aws-java:aws-java-sqs-1.0:compileTestGroovy

  Also verified against a demo application using AWS SDK 1.12.558, where producer and consumer spans now join the same trace.

  ## Tests

  Added coverage for:

  - latest AWS SDK v1 receive request system attribute handling
  - embedded Datadog attribute parsing for hex trace IDs and propagation tags

  ## Notes

  - This change intentionally updates the shared embedded _datadog parser, since the root cause is not limited to SQS v1 request shaping alone.
  - Commit includes AI-assisted changes.
