### PR TITLE
Make trace buffer size configurable

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -237,6 +237,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_TRACE_ANALYTICS_ENABLED = false;
   static final float DEFAULT_ANALYTICS_SAMPLE_RATE = 1.0f;
   static final int DEFAULT_TRACE_RATE_LIMIT = 100;
+  public static final int DEFAULT_TRACE_BUFFER_SIZE = 1024;
 
   public static final boolean DEFAULT_ASYNC_PROPAGATING = true;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -55,6 +55,7 @@ public final class TracerConfig {
   // a global rate used for all services (that don’t have a dedicated rule defined).
   public static final String TRACE_SAMPLE_RATE = "trace.sample.rate";
   public static final String TRACE_RATE_LIMIT = "trace.rate.limit";
+  public static final String TRACE_BUFFER_SIZE = "trace.buffer.size";
   public static final String TRACE_REPORT_HOSTNAME = "trace.report-hostname";
   public static final String TRACE_CLIENT_IP_HEADER = "trace.client-ip-header";
   public static final String TRACE_CLIENT_IP_RESOLVER_ENABLED = "trace.client-ip.resolver.enabled";

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -4,6 +4,7 @@ import static datadog.communication.http.OkHttpUtils.buildHttpClient;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_HOST;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_TIMEOUT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_BUFFER_SIZE;
 import static datadog.trace.common.writer.ddagent.Prioritization.FAST_LANE;
 
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
@@ -24,7 +25,7 @@ public class DDAgentWriter extends RemoteWriter {
     return new DDAgentWriterBuilder();
   }
 
-  private static final int BUFFER_SIZE = 1024;
+  static final int BUFFER_SIZE = DEFAULT_TRACE_BUFFER_SIZE;
 
   public static class DDAgentWriterBuilder {
 
@@ -33,7 +34,7 @@ public class DDAgentWriter extends RemoteWriter {
     String unixDomainSocket = null;
     String namedPipe = null;
     long timeoutMillis = TimeUnit.SECONDS.toMillis(DEFAULT_AGENT_TIMEOUT);
-    int traceBufferSize = BUFFER_SIZE;
+    int traceBufferSize = Config.get().getTraceBufferSize();
     HealthMetrics healthMetrics = HealthMetrics.NO_OP;
     int flushIntervalMilliseconds = 1000;
     Monitoring monitoring = Monitoring.DISABLED;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDIntakeWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDIntakeWriter.java
@@ -1,5 +1,7 @@
 package datadog.trace.common.writer;
 
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_BUFFER_SIZE;
+
 import datadog.communication.ddagent.DroppingPolicy;
 import datadog.metrics.api.Monitoring;
 import datadog.trace.api.Config;
@@ -18,7 +20,7 @@ public class DDIntakeWriter extends RemoteWriter {
   public static final String DEFAULT_INTAKE_VERSION = "v2";
   public static final long DEFAULT_INTAKE_TIMEOUT = 10; // timeout in seconds
 
-  private static final int BUFFER_SIZE = 1024;
+  static final int BUFFER_SIZE = DEFAULT_TRACE_BUFFER_SIZE;
 
   public static DDIntakeWriterBuilder builder() {
     return new DDIntakeWriterBuilder();
@@ -26,7 +28,7 @@ public class DDIntakeWriter extends RemoteWriter {
 
   public static class DDIntakeWriterBuilder {
     CiVisibilityWellKnownTags wellKnownTags = Config.get().getCiVisibilityWellKnownTags();
-    int traceBufferSize = BUFFER_SIZE;
+    int traceBufferSize = Config.get().getTraceBufferSize();
     HealthMetrics healthMetrics = HealthMetrics.NO_OP;
     int flushIntervalMilliseconds = 1000;
     Monitoring monitoring = Monitoring.DISABLED;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -104,6 +104,7 @@ public class WriterFactory {
       DDIntakeWriter.DDIntakeWriterBuilder builder =
           DDIntakeWriter.builder()
               .addTrack(trackType, remoteApi)
+              .traceBufferSize(config.getTraceBufferSize())
               .prioritization(prioritization)
               .healthMetrics(healthMetrics)
               .monitoring(commObjects.monitoring)
@@ -157,6 +158,7 @@ public class WriterFactory {
           DDAgentWriter.builder()
               .agentApi(ddAgentApi)
               .featureDiscovery(featuresDiscovery)
+              .traceBufferSize(config.getTraceBufferSize())
               .prioritization(prioritization)
               .healthMetrics(healthMetrics)
               .monitoring(commObjects.monitoring)

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Prioritization.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Prioritization.java
@@ -4,11 +4,15 @@ import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.USER_DROP;
 
 import datadog.communication.ddagent.DroppingPolicy;
+import datadog.trace.api.Config;
 import datadog.trace.core.CoreSpan;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public enum Prioritization {
   ENSURE_TRACE {
@@ -37,6 +41,47 @@ public enum Prioritization {
       Queue<Object> secondary,
       Queue<Object> spanSampling,
       DroppingPolicy droppingPolicy);
+
+  private static final Logger log = LoggerFactory.getLogger(Prioritization.class);
+
+  private static <T extends CoreSpan<T>> PrioritizationStrategy.PublishResult offerOrLogOverflow(
+      String queueName, Queue<Object> queue, T root, int priority, List<T> trace) {
+    if (queue.offer(trace)) {
+      return PrioritizationStrategy.PublishResult.ENQUEUED_FOR_SERIALIZATION;
+    }
+    logBufferOverflow(queueName, queue, root, priority, trace);
+    return PrioritizationStrategy.PublishResult.DROPPED_BUFFER_OVERFLOW;
+  }
+
+  private static <T extends CoreSpan<T>> PrioritizationStrategy.PublishResult offerOrLogSpanSamplingOverflow(
+      Queue<Object> queue, T root, int priority, List<T> trace) {
+    if (queue.offer(trace)) {
+      return PrioritizationStrategy.PublishResult.ENQUEUED_FOR_SINGLE_SPAN_SAMPLING;
+    }
+    logBufferOverflow("spanSampling", queue, root, priority, trace);
+    return PrioritizationStrategy.PublishResult.DROPPED_BUFFER_OVERFLOW;
+  }
+
+  private static <T extends CoreSpan<T>> void logBufferOverflow(
+      String queueName, Queue<Object> queue, T root, int priority, List<T> trace) {
+    Config config = Config.get();
+    if (!config.isDebugEnabled()) {
+      return;
+    }
+    int remainingCapacity = -1;
+    if (queue instanceof BlockingQueue) {
+      remainingCapacity = ((BlockingQueue<?>) queue).remainingCapacity();
+    }
+    log.debug(
+        "Trace buffer overflow on {} queue: traceBufferSize={}, queueSize={}, remainingCapacity={}, traceSize={}, priority={}, forceKeep={}",
+        queueName,
+        config.getTraceBufferSize(),
+        queue.size(),
+        remainingCapacity,
+        trace.size(),
+        priority,
+        root.isForceKeep());
+  }
 
   private abstract static class PrioritizationStrategyWithFlush implements PrioritizationStrategy {
 
@@ -90,13 +135,9 @@ public enum Prioritization {
         case USER_DROP:
           if (spanSampling != null) {
             // send dropped traces for single span sampling
-            return spanSampling.offer(trace)
-                ? PublishResult.ENQUEUED_FOR_SINGLE_SPAN_SAMPLING
-                : PublishResult.DROPPED_BUFFER_OVERFLOW;
+            return offerOrLogSpanSamplingOverflow(spanSampling, root, priority, trace);
           }
-          return secondary.offer(trace)
-              ? PublishResult.ENQUEUED_FOR_SERIALIZATION
-              : PublishResult.DROPPED_BUFFER_OVERFLOW;
+          return offerOrLogOverflow("secondary", secondary, root, priority, trace);
         default:
           blockingOffer(primary, trace);
           return PublishResult.ENQUEUED_FOR_SERIALIZATION;
@@ -124,29 +165,21 @@ public enum Prioritization {
     @Override
     public <T extends CoreSpan<T>> PublishResult publish(T root, int priority, List<T> trace) {
       if (root.isForceKeep()) {
-        return primary.offer(trace)
-            ? PublishResult.ENQUEUED_FOR_SERIALIZATION
-            : PublishResult.DROPPED_BUFFER_OVERFLOW;
+        return offerOrLogOverflow("primary", primary, root, priority, trace);
       }
       switch (priority) {
         case SAMPLER_DROP:
         case USER_DROP:
           if (spanSampling != null) {
             // send dropped traces for single span sampling
-            return spanSampling.offer(trace)
-                ? PublishResult.ENQUEUED_FOR_SINGLE_SPAN_SAMPLING
-                : PublishResult.DROPPED_BUFFER_OVERFLOW;
+            return offerOrLogSpanSamplingOverflow(spanSampling, root, priority, trace);
           }
           if (droppingPolicy.active()) {
             return PublishResult.DROPPED_BY_POLICY;
           }
-          return secondary.offer(trace)
-              ? PublishResult.ENQUEUED_FOR_SERIALIZATION
-              : PublishResult.DROPPED_BUFFER_OVERFLOW;
+          return offerOrLogOverflow("secondary", secondary, root, priority, trace);
         default:
-          return primary.offer(trace)
-              ? PublishResult.ENQUEUED_FOR_SERIALIZATION
-              : PublishResult.DROPPED_BUFFER_OVERFLOW;
+          return offerOrLogOverflow("primary", primary, root, priority, trace);
       }
     }
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/WriterFactoryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/WriterFactoryTest.groovy
@@ -31,6 +31,7 @@ class WriterFactoryTest extends DDSpecification {
     def config = Mock(Config)
     config.apiKey >> "my-api-key"
     config.agentUrl >> "http://my-agent.url"
+    config.traceBufferSize >> 1024
     config.getEnumValue(PRIORITIZATION_TYPE, _, _) >> Prioritization.FAST_LANE
     config.tracerMetricsEnabled >> true
     config.isCiVisibilityEnabled() >> true
@@ -103,6 +104,7 @@ class WriterFactoryTest extends DDSpecification {
     def config = Mock(Config)
     config.apiKey >> "my-api-key"
     config.agentUrl >> "http://my-agent.url"
+    config.traceBufferSize >> 1024
     config.getEnumValue(PRIORITIZATION_TYPE, _, _) >> Prioritization.FAST_LANE
     config.tracerMetricsEnabled >> true
     config.isLlmObsEnabled() >> true

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -169,6 +169,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANALYTICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_BAGGAGE_MAX_BYTES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_BAGGAGE_MAX_ITEMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_BAGGAGE_TAG_KEYS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_BUFFER_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_CLOUD_PAYLOAD_TAGGING_SERVICES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_DUBBO_PROVIDER_PROPAGATE_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_DUBBO_REQUEST_ENABLED;
@@ -655,6 +656,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_ANALYTICS_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_BAGGAGE_MAX_BYTES;
 import static datadog.trace.api.config.TracerConfig.TRACE_BAGGAGE_MAX_ITEMS;
 import static datadog.trace.api.config.TracerConfig.TRACE_BAGGAGE_TAG_KEYS;
+import static datadog.trace.api.config.TracerConfig.TRACE_BUFFER_SIZE;
 import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_HEADER;
 import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_CLOUD_PAYLOAD_TAGGING_MAX_DEPTH;
@@ -986,6 +988,7 @@ public class Config {
   private final String traceSamplingRules;
   private final Double traceSampleRate;
   private final int traceRateLimit;
+  private final int traceBufferSize;
   private final String spanSamplingRules;
   private final String spanSamplingRulesFile;
 
@@ -2096,6 +2099,7 @@ public class Config {
     traceSamplingRules = configProvider.getString(TRACE_SAMPLING_RULES);
     traceSampleRate = configProvider.getDouble(TRACE_SAMPLE_RATE);
     traceRateLimit = configProvider.getInteger(TRACE_RATE_LIMIT, DEFAULT_TRACE_RATE_LIMIT);
+    traceBufferSize = configProvider.getInteger(TRACE_BUFFER_SIZE, DEFAULT_TRACE_BUFFER_SIZE);
     spanSamplingRules = configProvider.getString(SPAN_SAMPLING_RULES);
     spanSamplingRulesFile = configProvider.getString(SPAN_SAMPLING_RULES_FILE);
 
@@ -3708,6 +3712,10 @@ public class Config {
 
   public int getTraceRateLimit() {
     return traceRateLimit;
+  }
+
+  public int getTraceBufferSize() {
+    return traceBufferSize;
   }
 
   public String getSpanSamplingRules() {
@@ -6173,6 +6181,8 @@ public class Config {
         + traceSampleRate
         + ", traceRateLimit="
         + traceRateLimit
+        + ", traceBufferSize="
+        + traceBufferSize
         + ", spanSamplingRules="
         + spanSamplingRules
         + ", spanSamplingRulesFile="

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -116,6 +116,7 @@ import static datadog.trace.api.config.TracerConfig.SPAN_TAGS
 import static datadog.trace.api.config.TracerConfig.SPLIT_BY_TAGS
 import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_PORT
 import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_URL
+import static datadog.trace.api.config.TracerConfig.TRACE_BUFFER_SIZE
 import static datadog.trace.api.config.TracerConfig.TRACE_EXPERIMENTAL_FEATURES_ENABLED
 import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_ENABLED
 import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_FLUSH_INTERVAL
@@ -283,6 +284,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(TRACE_SAMPLING_OPERATION_RULES, "b:1")
     prop.setProperty(TRACE_SAMPLE_RATE, ".5")
     prop.setProperty(TRACE_RATE_LIMIT, "200")
+    prop.setProperty(TRACE_BUFFER_SIZE, "2048")
     prop.setProperty(TRACE_LONG_RUNNING_ENABLED, "true")
     prop.setProperty(TRACE_LONG_RUNNING_FLUSH_INTERVAL, "250")
 
@@ -396,6 +398,7 @@ class ConfigTest extends DDSpecification {
     config.traceSamplingOperationRules == [b: "1"]
     config.traceSampleRate == 0.5
     config.traceRateLimit == 200
+    config.traceBufferSize == 2048
     config.isLongRunningTraceEnabled()
     config.getLongRunningTraceFlushInterval() == 250
 
@@ -695,6 +698,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + TRACE_SAMPLING_OPERATION_RULES, "b:1")
     System.setProperty(PREFIX + TRACE_SAMPLE_RATE, ".5")
     System.setProperty(PREFIX + TRACE_RATE_LIMIT, "200")
+    System.setProperty(PREFIX + TRACE_BUFFER_SIZE, "2048")
     System.setProperty(PREFIX + TRACE_LONG_RUNNING_ENABLED, "true")
     System.setProperty(PREFIX + TRACE_LONG_RUNNING_FLUSH_INTERVAL, "333")
 
@@ -806,6 +810,7 @@ class ConfigTest extends DDSpecification {
     config.traceSamplingOperationRules == [b: "1"]
     config.traceSampleRate == 0.5
     config.traceRateLimit == 200
+    config.traceBufferSize == 2048
     config.isLongRunningTraceEnabled()
     config.getLongRunningTraceFlushInterval() == 333
     config.traceRateLimit == 200

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -8625,6 +8625,14 @@
         "aliases": []
       }
     ],
+    "DD_TRACE_BUFFER_SIZE": [
+      {
+        "version": "A",
+        "type": "int",
+        "default": "1024",
+        "aliases": []
+      }
+    ],
     "DD_TRACE_RATPACK_ANALYTICS_ENABLED": [
       {
         "version": "A",


### PR DESCRIPTION
 ## Summary

  This PR makes the trace writer buffer size configurable and adds better debug diagnostics for `DROPPED_BUFFER_OVERFLOW`.

  ## Background

  We observed traces being dropped with logs like:

  `Dropped due to a buffer overflow`

  `DD_TRACE_RATE_LIMIT` was not the root cause here. That setting only affects local rule-based sampling.
  The actual drop happened later, when traces were enqueued into the writer processing queues.

  Previously:

  - the trace buffer size was effectively fixed at `1024`
  - the standard runtime path did not expose a config for it
  - overflow logs did not show which queue was full or what the buffer state was

  ## Changes

  - Added a new config:
    - `dd.trace.buffer.size`
    - `DD_TRACE_BUFFER_SIZE`
  - Default value remains `1024`
  - Wired the config into both:
    - `DDAgentWriter`
    - `DDIntakeWriter`
  - Updated builder defaults so direct `builder().build()` also honors runtime config
  - Centralized the default value in `ConfigDefaults`

  ## Debug Logging

  Added debug-only overflow logs at the actual queue `offer(...)` failure point in `Prioritization`.

```java
    log.debug(
        "Trace buffer overflow on {} queue: traceBufferSize={}, queueSize={}, remainingCapacity={}, traceSize={}, priority={}, forceKeep={}",
        queueName,
        config.getTraceBufferSize(),
        queue.size(),
        remainingCapacity,
        trace.size(),
        priority,
        root.isForceKeep());
```
  The new log includes:

  - queue name
  - configured `traceBufferSize`
  - queue size
  - remaining capacity
  - trace size
  - sampling priority
  - `forceKeep`

  This makes it much easier to understand whether overflow is happening on the `primary`, `secondary`, or `spanSampling` queue.

  ## Impact

  Users can now tune writer queue capacity without code changes, for example:

  ```bash
  DD_TRACE_BUFFER_SIZE=4096

  This change does not affect sampling logic. It only makes the writer buffer configurable and improves overflow visibility.
