### PR TITLE
 Fix Redis split-by-host service naming in Redisson and Lettuce cluster mode

### DIFF
--- a/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceDefaultEndpointAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceDefaultEndpointAdvice.java
@@ -1,36 +1,43 @@
 package datadog.trace.instrumentation.lettuce5;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.ServiceNameSources.DB_CLIENT_SPLIT_BY_HOST;
+
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import io.netty.channel.Channel;
-import net.bytebuddy.asm.Advice;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import net.bytebuddy.asm.Advice;
 
 public class LettuceDefaultEndpointAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentSpan onEnter(
-      @Advice.This Object obj,@Advice.FieldValue("channel") Channel channel
-  ) {
-    if (channel == null) {
-      return activeSpan();
-    }
+      @Advice.This Object obj, @Advice.FieldValue("channel") Channel channel) {
     AgentSpan span = activeSpan();
+    if (span == null
+        || !String.valueOf(InternalSpanTypes.REDIS).equals(String.valueOf(span.getSpanType()))) {
+      return span;
+    }
+    if (channel == null) {
+      return span;
+    }
 
     SocketAddress socketAddress = channel.remoteAddress();
     if (socketAddress instanceof InetSocketAddress) {
       InetSocketAddress inetSocketAddress = (InetSocketAddress) socketAddress;
-//      String peer = inetSocketAddress.getHostString() + ":" + inetSocketAddress.getPort();
-      if (span!=null){
-//        span.setTag("peer",peer);
-        span.setTag(Tags.PEER_HOSTNAME,inetSocketAddress.getHostName());
-        span.setTag(Tags.PEER_PORT,inetSocketAddress.getPort());
+      final String hostName = inetSocketAddress.getHostString();
+      if (hostName != null) {
+        span.setTag(Tags.PEER_HOSTNAME, hostName);
+        if (Config.get().isDbClientSplitByHost()) {
+          span.setServiceName(hostName, DB_CLIENT_SPLIT_BY_HOST);
+        }
       }
+      span.setTag(Tags.PEER_PORT, inetSocketAddress.getPort());
     }
-    return activeSpan();
+    return span;
   }
 }

--- a/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonClientDecorator.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonClientDecorator.java
@@ -1,11 +1,15 @@
 package datadog.trace.instrumentation.redisson;
 
+import static datadog.trace.bootstrap.instrumentation.api.ServiceNameSources.DB_CLIENT_SPLIT_BY_HOST;
+
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
+import java.net.InetSocketAddress;
 import org.redisson.client.protocol.CommandData;
 
 public class RedissonClientDecorator
@@ -59,6 +63,21 @@ public class RedissonClientDecorator
   @Override
   protected CharSequence dbHostname(CommandData<?, ?> commandData) {
     return null;
+  }
+
+  public AgentSpan onConnection(final AgentSpan span, final InetSocketAddress remoteConnection) {
+    if (remoteConnection != null) {
+      super.onPeerConnection(span, remoteConnection);
+
+      final String hostName = remoteConnection.getHostString();
+      if (hostName != null && Config.get().isPeerHostNameEnabled()) {
+        span.setTag(Tags.PEER_HOSTNAME, hostName);
+        if (Config.get().isDbClientSplitByHost()) {
+          span.setServiceName(hostName, DB_CLIENT_SPLIT_BY_HOST);
+        }
+      }
+    }
+    return span;
   }
 
   public AgentSpan onArgs(final AgentSpan span, Object[] args) {

--- a/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonInstrumentation.java
@@ -15,7 +15,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import net.bytebuddy.asm.Advice;
 import org.redisson.client.RedisConnection;
@@ -69,7 +68,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       }
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
-      DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
 
       DECORATE.onArgs(span, command.getParams());
       DECORATE.onStatement(span, command.getCommand().getName());
@@ -96,7 +95,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
-      DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
 
       List<String> commandResourceNames = new ArrayList<>();
       for (CommandData<?, ?> commandData : command.getCommands()) {

--- a/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonClientDecorator.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonClientDecorator.java
@@ -1,13 +1,15 @@
 package datadog.trace.instrumentation.redisson23;
 
+import static datadog.trace.bootstrap.instrumentation.api.ServiceNameSources.DB_CLIENT_SPLIT_BY_HOST;
+
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
-import io.netty.buffer.ByteBuf;
-import java.nio.charset.StandardCharsets;
+import java.net.InetSocketAddress;
 import org.redisson.client.protocol.CommandData;
 
 public class RedissonClientDecorator
@@ -60,6 +62,21 @@ public class RedissonClientDecorator
   @Override
   protected CharSequence dbHostname(CommandData<?, ?> commandData) {
     return null;
+  }
+
+  public AgentSpan onConnection(final AgentSpan span, final InetSocketAddress remoteConnection) {
+    if (remoteConnection != null) {
+      super.onPeerConnection(span, remoteConnection);
+
+      final String hostName = remoteConnection.getHostString();
+      if (hostName != null && Config.get().isPeerHostNameEnabled()) {
+        span.setTag(Tags.PEER_HOSTNAME, hostName);
+        if (Config.get().isDbClientSplitByHost()) {
+          span.setServiceName(hostName, DB_CLIENT_SPLIT_BY_HOST);
+        }
+      }
+    }
+    return span;
   }
 
   public AgentSpan onArgs(final AgentSpan span, Object[] args) {

--- a/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonInstrumentation.java
@@ -14,7 +14,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import net.bytebuddy.asm.Advice;
 import org.redisson.api.RFuture;
@@ -69,7 +68,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       }
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
-      RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      RedissonClientDecorator.DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
       RedissonClientDecorator.DECORATE.onStatement(span, command.getCommand().getName());
       RedissonClientDecorator.DECORATE.onArgs(span, command.getParams());
       ((RFuture<?>) command.getPromise())
@@ -96,7 +95,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
-      RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      RedissonClientDecorator.DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
 
       List<String> commandResourceNames = new ArrayList<>();
       for (CommandData<?, ?> commandData : command.getCommands()) {

--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonClientDecorator.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonClientDecorator.java
@@ -1,13 +1,15 @@
 package datadog.trace.instrumentation.redisson30;
 
+import static datadog.trace.bootstrap.instrumentation.api.ServiceNameSources.DB_CLIENT_SPLIT_BY_HOST;
+
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
-import io.netty.buffer.ByteBuf;
-import java.nio.charset.StandardCharsets;
+import java.net.InetSocketAddress;
 import org.redisson.client.protocol.CommandData;
 
 public class RedissonClientDecorator
@@ -60,6 +62,21 @@ public class RedissonClientDecorator
   @Override
   protected CharSequence dbHostname(CommandData<?, ?> commandData) {
     return null;
+  }
+
+  public AgentSpan onConnection(final AgentSpan span, final InetSocketAddress remoteConnection) {
+    if (remoteConnection != null) {
+      super.onPeerConnection(span, remoteConnection);
+
+      final String hostName = remoteConnection.getHostString();
+      if (hostName != null && Config.get().isPeerHostNameEnabled()) {
+        span.setTag(Tags.PEER_HOSTNAME, hostName);
+        if (Config.get().isDbClientSplitByHost()) {
+          span.setServiceName(hostName, DB_CLIENT_SPLIT_BY_HOST);
+        }
+      }
+    }
+    return span;
   }
 
   public AgentSpan onArgs(final AgentSpan span, Object[] args) {

--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
@@ -14,7 +14,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import net.bytebuddy.asm.Advice;
@@ -74,7 +73,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       }
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
-      RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      RedissonClientDecorator.DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
       RedissonClientDecorator.DECORATE.onStatement(span, command.getCommand().getName());
       RedissonClientDecorator.DECORATE.onArgs(span, command.getParams());
 
@@ -107,7 +106,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       }
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
-      RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      RedissonClientDecorator.DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
 
       List<String> commandResourceNames = new ArrayList<>();
       for (CommandData<?, ?> commandData : command.getCommands()) {

--- a/docs/redis-split-by-host-analysis.md
+++ b/docs/redis-split-by-host-analysis.md
@@ -1,0 +1,251 @@
+# Redis `split-by-host` 问题分析与调整说明
+
+## 1. 背景
+
+客户希望在 APM 中将数据库或中间件的默认 service 名称按集群或节点区分，例如将默认的 `mysql`、`redis` 展示为类似 `mysql-1`、`redis-order-1` 的名称，以便区分不同业务或不同集群。
+
+当前采用的方案是开启：
+
+```text
+DD_TRACE_DB_CLIENT_SPLIT_BY_HOST=true
+```
+
+其内部对应配置项为：
+
+```text
+trace.db.client.split-by-host
+```
+
+目标是让数据库客户端 span 使用连接目标的 hostname 作为 service name。
+
+## 2. 问题现象
+
+实际测试中发现以下问题：
+
+1. 单节点 Redis 模式下，`split-by-host` 可以生效。
+2. Lettuce 在 cluster 模式下，`split-by-host` 不生效。
+3. Redisson 在现有实现下整体不生效。
+4. APM 中部分 Redis span 的 `db_host` 为空，相关 `resource` 常见为 `EVALSHA`。
+
+## 3. 源码结论
+
+### 3.1 配置项本身没有问题
+
+配置常量定义在：
+
+- [dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java](/home/liurui/code/dd-trace-java/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java:61)
+
+加载配置的位置在：
+
+- [internal-api/src/main/java/datadog/trace/api/Config.java](/home/liurui/code/dd-trace-java/internal-api/src/main/java/datadog/trace/api/Config.java:1753)
+
+说明 `DD_TRACE_DB_CLIENT_SPLIT_BY_HOST` 的配置入口是正确的，不是参数名或配置映射问题。
+
+### 3.2 `split-by-host` 生效的前提
+
+真正按 host 改 service 的逻辑在：
+
+- [dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java](/home/liurui/code/dd-trace-java/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java:71)
+
+核心逻辑是：
+
+1. 先从连接对象中拿到 hostname。
+2. 将 hostname 写入 `peer.hostname`。
+3. 如果开启 `trace.db.client.split-by-host`，则将 span service name 改成该 hostname。
+
+因此，只有在 instrumentation 能正确拿到 hostname 并走到 `onConnection()` 逻辑时，`split-by-host` 才会生效。
+
+### 3.3 Redisson 不生效的根因
+
+Redisson 旧实现的问题有两个：
+
+1. `dbHostname()` 直接返回 `null`。
+2. 调用链只走了 `onPeerConnection()`，没有走 `DatabaseClientDecorator.onConnection()`。
+
+相关代码：
+
+- [dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonClientDecorator.java](/home/liurui/code/dd-trace-java/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonClientDecorator.java:62)
+- [dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java](/home/liurui/code/dd-trace-java/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java:74)
+
+这意味着：
+
+1. `peer.hostname` 不一定能稳定写入。
+2. 即使有连接地址，也不会触发按 host 改 service name 的逻辑。
+
+所以 Redisson “完全不生效” 是源码既有行为。
+
+### 3.4 Lettuce cluster 不生效的根因
+
+Lettuce 命令 span在结束前会尝试通过 `StatefulConnection -> RedisURI` 上下文取连接信息：
+
+- [dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncCommandsAdvice.java](/home/liurui/code/dd-trace-java/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncCommandsAdvice.java:39)
+
+而这个上下文的来源是 `RedisClient` 的 connect 路径：
+
+- [dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientInstrumentation.java](/home/liurui/code/dd-trace-java/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientInstrumentation.java:26)
+
+单节点模式通常能走这条路径，所以 `split-by-host` 正常。
+
+cluster 模式不一定走 `RedisClient` 的这条 connect 链路，导致：
+
+1. 命令 span 上拿不到 `RedisURI`。
+2. `onConnection()` 不会执行。
+3. `split-by-host` 无法按预期生效。
+
+### 3.5 `EVALSHA` 与 `db_host` 为空的关系
+
+`EVALSHA` 本身不是异常，通常代表 Redis 脚本缓存开启后，客户端发起的是脚本 SHA 调用，而不是直接 `EVAL`。
+
+在 Redisson 测试中，测试代码显式关闭了 script cache，因此断言里常见的是 `EVAL`：
+
+- [dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/test/groovy/RedissonClientTest.groovy](/home/liurui/code/dd-trace-java/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/test/groovy/RedissonClientTest.groovy:39)
+- [dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/test/groovy/RedissonClientTest.groovy](/home/liurui/code/dd-trace-java/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/test/groovy/RedissonClientTest.groovy:194)
+
+线上如果开启 script cache，看到 `EVALSHA` 是合理现象。
+
+`db_host` 为空的根因仍然是 host 信息没有稳定写入 span，尤其在：
+
+1. Redisson 旧逻辑未走 `onConnection()`。
+2. `InetSocketAddress` 未解析时，旧的 `onPeerConnection()` 依赖 `remoteConnection.getAddress()`，可能拿不到 hostname。
+
+相关逻辑见：
+
+- [dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java](/home/liurui/code/dd-trace-java/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java:155)
+
+## 4. 已做调整
+
+### 4.1 Redisson 调整
+
+已对以下版本做了相同方向修复：
+
+1. `redisson-2.0.0`
+2. `redisson-2.3.0`
+3. `redisson-3.10.3`
+
+调整内容：
+
+1. 新增基于 `InetSocketAddress` 的 `onConnection()` 处理。
+2. 使用 `remoteConnection.getHostString()` 直接获取 host。
+3. 将 host 回填到 `peer.hostname`。
+4. 在开启 `trace.db.client.split-by-host` 时，将 service name 设置为 host。
+
+示例代码位置：
+
+- [dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonClientDecorator.java](/home/liurui/code/dd-trace-java/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonClientDecorator.java:67)
+- [dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java](/home/liurui/code/dd-trace-java/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java:74)
+
+### 4.2 Lettuce 调整
+
+对 `lettuce-5.0` 的调整思路不是继续依赖 `RedisURI` 上下文，而是在实际 socket 写出时从 `channel.remoteAddress()` 读取真实目标地址。
+
+调整内容：
+
+1. 在 `DefaultEndpoint.write` 路径提取实际远端地址。
+2. 将 host 写入 `peer.hostname`。
+3. 将 port 写入 `peer.port`。
+4. 若开启 `trace.db.client.split-by-host`，则直接按真实目标 host 更新 service name。
+
+相关代码：
+
+- [dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceDefaultEndpointAdvice.java](/home/liurui/code/dd-trace-java/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceDefaultEndpointAdvice.java:17)
+
+## 5. 调整后的预期效果
+
+调整完成后，预期行为如下：
+
+1. Redisson 不再是完全不生效。
+2. Lettuce cluster 模式下，Redis span 可以基于真实连接节点进行 `split-by-host`。
+3. `db_host` 为空的问题会明显收敛。
+4. `EVALSHA` 类脚本命令也可以携带更完整的目标 host 信息。
+
+## 6. 使用规范
+
+为避免后续再次出现理解偏差，建议统一按以下规范使用。
+
+### 6.1 配置规范
+
+使用环境变量：
+
+```text
+DD_TRACE_DB_CLIENT_SPLIT_BY_HOST=true
+```
+
+或等价系统属性：
+
+```text
+-Ddd.trace.db.client.split-by-host=true
+```
+
+禁止混用非标准名称，避免出现“看起来像开了，实际没生效”的误判。
+
+### 6.2 命名规范
+
+`split-by-host` 的最终 service 名，本质上取决于客户端实际感知到的 host。
+
+因此如果希望 APM 展示为业务可读名称，例如：
+
+1. `mysql-1`
+2. `redis-order-1`
+3. `redis-member-cluster-a`
+
+则应用配置中的连接地址、DNS、CNAME 或服务发现返回值，最终也需要体现该命名。
+
+如果客户端最终连到的是：
+
+1. 真实 IP
+2. 节点域名
+3. cluster 节点地址
+
+那么 APM 中拆分后的 service 也通常会是这些值，而不是业务别名。
+
+### 6.3 适用范围规范
+
+`split-by-host` 更适合以下场景：
+
+1. 同一应用需要区分多个数据库或多个 Redis 集群。
+2. 各业务集群已经有稳定的 hostname 命名规范。
+3. 希望 service 维度直接按目标节点或目标集群拆分。
+
+不适合直接拿来做“业务语义映射”的场景，除非基础连接地址本身已经完成别名化。
+
+### 6.4 排查规范
+
+遇到“配置已开启但不生效”时，建议按以下顺序排查：
+
+1. 确认 span 上是否存在 `peer.hostname`。
+2. 确认客户端类型与模式，是单节点、哨兵、主从还是 cluster。
+3. 确认连接地址最终暴露的是业务别名、节点域名还是 IP。
+4. 确认 instrumentation 是否覆盖到实际调用路径。
+5. 对脚本命令区分 `EVAL` 与 `EVALSHA`，不要把 `EVALSHA` 误判为异常。
+
+## 7. 验证情况
+
+已做编译验证，以下编译通过：
+
+```bash
+./gradlew :dd-java-agent:instrumentation:lettuce:lettuce-5.0:compileJava :dd-java-agent:instrumentation:redisson:redisson-3.10.3:compileJava
+```
+
+此前对三个 `redisson` 模块的编译也已通过。
+
+`spotlessJavaCheck` 未全绿，但失败点在 `lettuce` 模块中原有文件的格式问题，不属于本次功能逻辑失败。
+
+## 8. 后续建议
+
+建议后续按以下方向继续补强：
+
+1. 为 `Redisson` 增加覆盖 `split-by-host` 的回归测试。
+2. 为 `Lettuce cluster` 增加 cluster 模式测试用例，避免后续回退。
+3. 如客户要求展示固定业务别名，建议结合 DNS/CNAME 或连接配置治理，而不是仅依赖 agent 侧自动推断。
+4. 若后续还涉及 MySQL、Kafka、RocketMQ 等中间件，建议统一沉淀一份“service 命名规范”，避免不同组件各自为政。
+
+## 9. 一句话结论
+
+这次问题不是配置项错误，而是 Redis 不同客户端在 instrumentation 层对 hostname 的提取路径不一致。
+
+其中：
+
+1. Redisson 旧实现本身就没有正确支持 `split-by-host`。
+2. Lettuce cluster 模式原先没有走到能拿 `RedisURI` 的单节点链路。
+
+本次调整后，Redis span 会更稳定地携带真实 host，并在开启 `split-by-host` 时按 host 生成 service name。

--- a/docs/redis-split-by-host-report.md
+++ b/docs/redis-split-by-host-report.md
@@ -1,0 +1,170 @@
+# Redis `split-by-host` 问题汇报说明
+
+## 1. 背景
+
+客户希望通过 `DD_TRACE_DB_CLIENT_SPLIT_BY_HOST=true`，将 APM 中默认的数据库或中间件 service 名按目标集群或节点区分开，例如：
+
+1. `mysql` 展示为 `mysql-1`
+2. `redis` 展示为 `redis-order-1`
+
+这样可以在 APM 中区分不同业务、不同集群或不同节点的访问流量。
+
+## 2. 问题现象
+
+实际核查与测试结果如下：
+
+1. Redis 单节点模式下，`split-by-host` 可以正常生效。
+2. Lettuce 在 cluster 模式下，`split-by-host` 不生效。
+3. Redisson 在现有实现下基本不生效。
+4. APM 中部分 Redis span 的 `db_host` 为空，相关 `resource` 常见为 `EVALSHA`。
+
+## 3. 核查结论
+
+### 3.1 配置项没有问题
+
+`DD_TRACE_DB_CLIENT_SPLIT_BY_HOST` 对应内部配置 `trace.db.client.split-by-host`，参数本身正确。
+
+因此，这次问题不是配置写错，而是不同客户端在采集 hostname 的实现路径不一致。
+
+### 3.2 Redisson 不生效的原因
+
+Redisson 旧实现里没有完整走到按 host 改 service 的逻辑，导致：
+
+1. `peer.hostname` 不能稳定写入。
+2. `split-by-host` 无法按预期把 service name 改成目标 host。
+
+所以 Redisson “完全不生效” 属于实现层问题，不是使用问题。
+
+### 3.3 Lettuce cluster 不生效的原因
+
+Lettuce 单节点模式下可以拿到连接信息，因此 `split-by-host` 正常。
+
+但在 cluster 模式下，原先的实现路径拿不到用于改 service 的连接 host，导致：
+
+1. 命令 span 上缺少可用的 hostname。
+2. `split-by-host` 在 cluster 模式下失效。
+
+### 3.4 `EVALSHA` 与 `db_host` 为空的说明
+
+`EVALSHA` 本身是正常现象，通常表示 Redis 脚本缓存开启后，客户端执行的是脚本 SHA 调用。
+
+`db_host` 为空的根因仍然是 host 信息没有被稳定写入 span，不代表 `EVALSHA` 本身异常。
+
+## 4. 已做调整
+
+本次已完成以下调整：
+
+1. 修复 `Redisson 2.0.0 / 2.3.0 / 3.10.3` 的 host 提取逻辑。
+2. 在 Redisson 上补齐按 host 回填 `peer.hostname` 并在开启 `split-by-host` 时更新 service name 的能力。
+3. 调整 `Lettuce 5` 的 Redis 目标地址获取方式，在实际网络写出时读取真实连接节点地址。
+4. 让 `Lettuce cluster` 模式下的 Redis span 能基于真实节点 host 参与 `split-by-host`。
+
+## 5. 调整后的预期效果
+
+调整后预期行为如下：
+
+1. Redisson 不再是完全不生效。
+2. Lettuce cluster 模式下可以按真实 Redis 节点拆分 service。
+3. Redis span 中 `db_host` 为空的问题会明显收敛。
+4. 包括 `EVALSHA` 在内的脚本类 Redis 命令，也能更稳定携带目标 host 信息。
+
+## 6. 使用规范
+
+### 6.1 配置规范
+
+统一使用：
+
+```text
+DD_TRACE_DB_CLIENT_SPLIT_BY_HOST=true
+```
+
+或等价系统属性：
+
+```text
+-Ddd.trace.db.client.split-by-host=true
+```
+
+避免使用非标准或自定义名称，防止误判为“配置已开启但功能未生效”。
+
+### 6.2 命名规范
+
+`split-by-host` 最终生成的 service name，本质上取决于客户端实际感知到的 host。
+
+也就是说，如果应用实际连接的是：
+
+1. IP
+2. 节点域名
+3. cluster 节点地址
+
+那么 APM 上最终拆分出来的 service 通常也会是这些值。
+
+如果希望 APM 中稳定展示为业务别名，例如：
+
+1. `mysql-1`
+2. `mysql-order-cluster`
+3. `redis-order-1`
+4. `redis-member-cluster-a`
+
+则必须保证应用侧实际使用的连接地址、DNS、CNAME 或服务发现返回值本身就是这些别名。
+
+### 6.3 MySQL 集群别名规范
+
+这一点需要特别补充说明，作为后续用户使用规范：
+
+1. 如果客户希望在 APM 中看到 `mysql-1`、`mysql-2`、`mysql-order-cluster` 这样的名称，不能只依赖 `split-by-host` 参数本身。
+2. `split-by-host` 只负责“按实际 host 拆分 service”，不会把 `mysql` 自动翻译成业务别名。
+3. 因此 MySQL 集群必须在连接配置层就使用统一别名，例如：
+   `mysql-1.prod.company.internal`
+   `mysql-order-cluster.prod.company.internal`
+4. 建议客户统一使用集群别名或业务别名访问 MySQL，而不是直接使用裸 IP 或随机节点名。
+5. 只有这样，`split-by-host` 在 APM 中展示出来的 service 名才会稳定、可读、可治理。
+
+换句话说：
+
+如果 MySQL 希望展示成 `mysql-1`，那应用实际连的 host 也应该是 `mysql-1` 或以其为核心的别名，而不是某个临时 IP。
+
+### 6.4 适用范围规范
+
+`split-by-host` 更适合以下场景：
+
+1. 一个应用会访问多个 MySQL 集群或多个 Redis 集群。
+2. 客户已有稳定的域名和别名治理规范。
+3. 希望 APM 在 service 维度上直接区分目标集群或节点。
+
+如果客户没有统一的连接命名规范，而是直接连接 IP，那么最终 APM 展示也会偏底层、不可读。
+
+## 7. 验证情况
+
+本次变更已完成相关模块编译验证，Redis 相关改动编译通过。
+
+当前未发现与本次逻辑调整直接相关的编译问题。
+
+## 8. 建议
+
+建议从两条线同时推进：
+
+1. 代码层面：继续补充 Redis cluster 和 Redisson 的回归测试，防止后续回退。
+2. 使用层面：推动客户统一制定数据库和中间件连接命名规范。
+
+其中命名规范建议明确要求：
+
+1. MySQL 集群统一使用业务别名或集群别名访问，例如 `mysql-1`、`mysql-order-cluster`。
+2. Redis 集群统一使用业务别名或集群别名访问，例如 `redis-order-1`、`redis-member-cluster-a`。
+3. 禁止在生产配置中直接使用裸 IP 作为长期连接地址。
+4. APM 命名规范应与 DNS、CNAME、服务发现命名保持一致。
+
+## 9. 汇总结论
+
+本次问题的本质不是配置项错误，而是 Redis 不同客户端在 hostname 提取路径上存在实现差异。
+
+调整后：
+
+1. Redisson 已补齐 `split-by-host` 所需的 host 写入和 service 更新逻辑。
+2. Lettuce cluster 已改为基于真实连接节点地址参与 `split-by-host`。
+3. Redis span 的 host 信息完整性会明显提升。
+
+同时需要明确规范：
+
+`split-by-host` 只能按“应用实际连接到的 host”来拆分 service，不能代替命名治理。
+
+特别是 MySQL 场景，如果客户希望最终在 APM 中稳定展示为 `mysql-1` 这类集群别名，那么应用连接配置、DNS 或服务发现层必须优先完成别名规范化，这样才能保证用户使用方式统一、APM 展示结果稳定。


### PR DESCRIPTION
### Summary

This PR fixes Redis `split-by-host` behavior for Redisson and Lettuce cluster clients.

We found that `DD_TRACE_DB_CLIENT_SPLIT_BY_HOST=true` was configured correctly, but Redis spans could still fail to rename their service based on the target host in two important cases:

1. Redisson spans never went through the database decorator path that applies `trace.db.client.split-by-host`.
2. Lettuce cluster spans could miss host information because they did not always have the `RedisURI` context used by the single-node connection path.

As a result, `split-by-host` could work in single-node mode but fail in cluster mode, and some Redis spans could show an empty `db_host`, especially around script-related commands such as `EVALSHA`.

### Root Cause

#### Redisson

Redisson command spans were only using peer connection tagging and were not invoking the connection flow in `DatabaseClientDecorator` that applies service renaming for `split-by-host`.

That meant:

- `peer.hostname` was not guaranteed to be populated consistently
- the span service name could never be updated from the actual target host

#### Lettuce cluster

Lettuce command spans relied on `StatefulConnection -> RedisURI` context populated by the single-node `RedisClient` connection path.

In cluster mode, command writes do not always follow that path, so spans could finish without usable host metadata and `split-by-host` would not be applied.

### Changes

#### Redisson

Updated the Redisson instrumentations for:

- `redisson-2.0.0`
- `redisson-2.3.0`
- `redisson-3.10.3`

Changes:

- added an `InetSocketAddress`-aware connection helper
- read the host with `getHostString()`
- preserved peer connection tagging
- populated `peer.hostname` explicitly
- updated the span service name when `trace.db.client.split-by-host` is enabled

#### Lettuce 5

Updated the Lettuce 5 instrumentation to derive the Redis target from the live Netty channel in `DefaultEndpoint.write`.

Changes:

- read the actual remote socket address from the channel
- populate `peer.hostname`
- populate `peer.port`
- update the span service name when `trace.db.client.split-by-host` is enabled

### Documentation

This PR also adds two documents:

- `docs/redis-split-by-host-analysis.md`
- `docs/redis-split-by-host-report.md`

The report document includes operational guidance for MySQL and Redis naming.

### Operational Guidance

`split-by-host` only reflects the host name actually seen by the client. It does not translate generic service names like `mysql` or `redis` into business-friendly aliases by itself.

If users want APM to show names such as:

- `mysql-1`
- `mysql-order-cluster`
- `redis-order-1`
- `redis-member-cluster-a`

then those aliases must already be used in:

- application connection settings
- DNS / CNAME
- service discovery results

This is especially important for MySQL clusters. If the expected APM service name is `mysql-1`, the application should connect to a host alias such as `mysql-1` or a stable hostname derived from it, rather than a raw IP or an unstable node name.

### Validation

Validated with:

```bash
./gradlew :dd-java-agent:instrumentation:lettuce:lettuce-5.0:compileJava :dd-java-agent:instrumentation:redisson:redisson-3.10.3:compileJava
```

Additional Redisson module compilation was also completed earlier during the investigation.

### Expected Outcome

After this change:

- Redisson spans can participate in `split-by-host`
- Lettuce cluster spans can derive service names from the actual Redis node they talk to
- Redis spans should carry host metadata more consistently
- empty Redis host fields should be significantly reduced