### PR TITLE
Fix Redis split-by-host naming and RabbitMQ consumer host enrichment

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,7 @@
+# Changelog
+
+按日期记录项目功能与代码提交。
+
+## 2026-04-29
+
+- 15:06 提交代码：新增 kafka-rabbitmq-business-mapping-report.md, kafka-rabbitmq-customer-reply.md, redis-split-by-host-pr.md；更新 AbstractMessageListenerContainerInstrumentation.java, BlockingQueueConsumerInstrumentation.java, SpringAmqpTest.groovy

--- a/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceDefaultEndpointAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce/lettuce-5.0/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceDefaultEndpointAdvice.java
@@ -1,36 +1,43 @@
 package datadog.trace.instrumentation.lettuce5;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.ServiceNameSources.DB_CLIENT_SPLIT_BY_HOST;
+
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import io.netty.channel.Channel;
-import net.bytebuddy.asm.Advice;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import net.bytebuddy.asm.Advice;
 
 public class LettuceDefaultEndpointAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentSpan onEnter(
-      @Advice.This Object obj,@Advice.FieldValue("channel") Channel channel
-  ) {
-    if (channel == null) {
-      return activeSpan();
-    }
+      @Advice.This Object obj, @Advice.FieldValue("channel") Channel channel) {
     AgentSpan span = activeSpan();
+    if (span == null
+        || !String.valueOf(InternalSpanTypes.REDIS).equals(String.valueOf(span.getSpanType()))) {
+      return span;
+    }
+    if (channel == null) {
+      return span;
+    }
 
     SocketAddress socketAddress = channel.remoteAddress();
     if (socketAddress instanceof InetSocketAddress) {
       InetSocketAddress inetSocketAddress = (InetSocketAddress) socketAddress;
-//      String peer = inetSocketAddress.getHostString() + ":" + inetSocketAddress.getPort();
-      if (span!=null){
-//        span.setTag("peer",peer);
-        span.setTag(Tags.PEER_HOSTNAME,inetSocketAddress.getHostName());
-        span.setTag(Tags.PEER_PORT,inetSocketAddress.getPort());
+      final String hostName = inetSocketAddress.getHostString();
+      if (hostName != null) {
+        span.setTag(Tags.PEER_HOSTNAME, hostName);
+        if (Config.get().isDbClientSplitByHost()) {
+          span.setServiceName(hostName, DB_CLIENT_SPLIT_BY_HOST);
+        }
       }
+      span.setTag(Tags.PEER_PORT, inetSocketAddress.getPort());
     }
-    return activeSpan();
+    return span;
   }
 }

--- a/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonClientDecorator.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonClientDecorator.java
@@ -1,11 +1,15 @@
 package datadog.trace.instrumentation.redisson;
 
+import static datadog.trace.bootstrap.instrumentation.api.ServiceNameSources.DB_CLIENT_SPLIT_BY_HOST;
+
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
+import java.net.InetSocketAddress;
 import org.redisson.client.protocol.CommandData;
 
 public class RedissonClientDecorator
@@ -59,6 +63,21 @@ public class RedissonClientDecorator
   @Override
   protected CharSequence dbHostname(CommandData<?, ?> commandData) {
     return null;
+  }
+
+  public AgentSpan onConnection(final AgentSpan span, final InetSocketAddress remoteConnection) {
+    if (remoteConnection != null) {
+      super.onPeerConnection(span, remoteConnection);
+
+      final String hostName = remoteConnection.getHostString();
+      if (hostName != null && Config.get().isPeerHostNameEnabled()) {
+        span.setTag(Tags.PEER_HOSTNAME, hostName);
+        if (Config.get().isDbClientSplitByHost()) {
+          span.setServiceName(hostName, DB_CLIENT_SPLIT_BY_HOST);
+        }
+      }
+    }
+    return span;
   }
 
   public AgentSpan onArgs(final AgentSpan span, Object[] args) {

--- a/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonInstrumentation.java
@@ -15,7 +15,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import net.bytebuddy.asm.Advice;
 import org.redisson.client.RedisConnection;
@@ -69,7 +68,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       }
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
-      DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
 
       DECORATE.onArgs(span, command.getParams());
       DECORATE.onStatement(span, command.getCommand().getName());
@@ -96,7 +95,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
-      DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
 
       List<String> commandResourceNames = new ArrayList<>();
       for (CommandData<?, ?> commandData : command.getCommands()) {

--- a/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonClientDecorator.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonClientDecorator.java
@@ -1,13 +1,15 @@
 package datadog.trace.instrumentation.redisson23;
 
+import static datadog.trace.bootstrap.instrumentation.api.ServiceNameSources.DB_CLIENT_SPLIT_BY_HOST;
+
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
-import io.netty.buffer.ByteBuf;
-import java.nio.charset.StandardCharsets;
+import java.net.InetSocketAddress;
 import org.redisson.client.protocol.CommandData;
 
 public class RedissonClientDecorator
@@ -60,6 +62,21 @@ public class RedissonClientDecorator
   @Override
   protected CharSequence dbHostname(CommandData<?, ?> commandData) {
     return null;
+  }
+
+  public AgentSpan onConnection(final AgentSpan span, final InetSocketAddress remoteConnection) {
+    if (remoteConnection != null) {
+      super.onPeerConnection(span, remoteConnection);
+
+      final String hostName = remoteConnection.getHostString();
+      if (hostName != null && Config.get().isPeerHostNameEnabled()) {
+        span.setTag(Tags.PEER_HOSTNAME, hostName);
+        if (Config.get().isDbClientSplitByHost()) {
+          span.setServiceName(hostName, DB_CLIENT_SPLIT_BY_HOST);
+        }
+      }
+    }
+    return span;
   }
 
   public AgentSpan onArgs(final AgentSpan span, Object[] args) {

--- a/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonInstrumentation.java
@@ -14,7 +14,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import net.bytebuddy.asm.Advice;
 import org.redisson.api.RFuture;
@@ -69,7 +68,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       }
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
-      RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      RedissonClientDecorator.DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
       RedissonClientDecorator.DECORATE.onStatement(span, command.getCommand().getName());
       RedissonClientDecorator.DECORATE.onArgs(span, command.getParams());
       ((RFuture<?>) command.getPromise())
@@ -96,7 +95,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
-      RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      RedissonClientDecorator.DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
 
       List<String> commandResourceNames = new ArrayList<>();
       for (CommandData<?, ?> commandData : command.getCommands()) {

--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonClientDecorator.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonClientDecorator.java
@@ -1,13 +1,15 @@
 package datadog.trace.instrumentation.redisson30;
 
+import static datadog.trace.bootstrap.instrumentation.api.ServiceNameSources.DB_CLIENT_SPLIT_BY_HOST;
+
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
-import io.netty.buffer.ByteBuf;
-import java.nio.charset.StandardCharsets;
+import java.net.InetSocketAddress;
 import org.redisson.client.protocol.CommandData;
 
 public class RedissonClientDecorator
@@ -60,6 +62,21 @@ public class RedissonClientDecorator
   @Override
   protected CharSequence dbHostname(CommandData<?, ?> commandData) {
     return null;
+  }
+
+  public AgentSpan onConnection(final AgentSpan span, final InetSocketAddress remoteConnection) {
+    if (remoteConnection != null) {
+      super.onPeerConnection(span, remoteConnection);
+
+      final String hostName = remoteConnection.getHostString();
+      if (hostName != null && Config.get().isPeerHostNameEnabled()) {
+        span.setTag(Tags.PEER_HOSTNAME, hostName);
+        if (Config.get().isDbClientSplitByHost()) {
+          span.setServiceName(hostName, DB_CLIENT_SPLIT_BY_HOST);
+        }
+      }
+    }
+    return span;
   }
 
   public AgentSpan onArgs(final AgentSpan span, Object[] args) {

--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
@@ -14,7 +14,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import net.bytebuddy.asm.Advice;
@@ -74,7 +73,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       }
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
-      RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      RedissonClientDecorator.DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
       RedissonClientDecorator.DECORATE.onStatement(span, command.getCommand().getName());
       RedissonClientDecorator.DECORATE.onArgs(span, command.getParams());
 
@@ -107,7 +106,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       }
       final AgentSpan span = startSpan(RedissonClientDecorator.OPERATION_NAME);
       RedissonClientDecorator.DECORATE.afterStart(span);
-      RedissonClientDecorator.DECORATE.onPeerConnection(span, thiz.getRedisClient().getAddr());
+      RedissonClientDecorator.DECORATE.onConnection(span, thiz.getRedisClient().getAddr());
 
       List<String> commandResourceNames = new ArrayList<>();
       for (CommandData<?, ?> commandData : command.getCommands()) {

--- a/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/src/main/java/datadog/trace/instrumentation/springamqp/AbstractMessageListenerContainerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/src/main/java/datadog/trace/instrumentation/springamqp/AbstractMessageListenerContainerInstrumentation.java
@@ -19,10 +19,13 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
+import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
 
 @AutoService(InstrumenterModule.class)
 public class AbstractMessageListenerContainerInstrumentation extends InstrumenterModule.Tracing
@@ -44,7 +47,11 @@ public class AbstractMessageListenerContainerInstrumentation extends Instrumente
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("org.springframework.amqp.core.Message", State.class.getName());
+    Map<String, String> contextStore = new HashMap<>();
+    contextStore.put("org.springframework.amqp.core.Message", State.class.getName());
+    contextStore.put(
+        "org.springframework.amqp.core.MessageProperties", InetSocketAddress.class.getName());
+    return contextStore;
   }
 
   @Override
@@ -75,6 +82,15 @@ public class AbstractMessageListenerContainerInstrumentation extends Instrumente
               AgentSpan span = startSpan(AMQP_CONSUME);
               span.setMeasured(true);
               DECORATE.afterStart(span);
+              MessageProperties properties = message.getMessageProperties();
+              if (properties != null) {
+                InetSocketAddress connection =
+                    InstrumentationContext.get(MessageProperties.class, InetSocketAddress.class)
+                        .get(properties);
+                if (connection != null) {
+                  DECORATE.onPeerConnection(span, connection);
+                }
+              }
               DECORATE.onConsume(span, message.getMessageProperties().getConsumerQueue());
               return activateSpan(span);
             }

--- a/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/src/main/java/datadog/trace/instrumentation/springamqp/BlockingQueueConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/src/main/java/datadog/trace/instrumentation/springamqp/BlockingQueueConsumerInstrumentation.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.springamqp;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.instrumentation.springamqp.RabbitListenerDecorator.DECORATE;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
@@ -8,11 +10,17 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.TreeMap;
 import net.bytebuddy.asm.Advice;
 import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.support.Delivery;
 
 @AutoService(InstrumenterModule.class)
@@ -28,6 +36,11 @@ public class BlockingQueueConsumerInstrumentation extends InstrumenterModule.Tra
   }
 
   @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".RabbitListenerDecorator"};
+  }
+
+  @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         named("handle")
@@ -39,6 +52,7 @@ public class BlockingQueueConsumerInstrumentation extends InstrumenterModule.Tra
   public Map<String, String> contextStore() {
     Map<String, String> contextStore = new TreeMap<>();
     contextStore.put("org.springframework.amqp.core.Message", State.class.getName());
+    contextStore.put("org.springframework.amqp.core.MessageProperties", InetSocketAddress.class.getName());
     contextStore.put("org.springframework.amqp.rabbit.support.Delivery", State.class.getName());
     return contextStore;
   }
@@ -46,7 +60,23 @@ public class BlockingQueueConsumerInstrumentation extends InstrumenterModule.Tra
   public static class TransferState {
     @Advice.OnMethodExit
     public static void transfer(
-        @Advice.Argument(0) Delivery delivery, @Advice.Return Message message) {
+        @Advice.This Object consumer,
+        @Advice.Argument(0) Delivery delivery,
+        @Advice.Return Message message) {
+      InetSocketAddress connection = extractConnection(consumer);
+      if (connection != null) {
+        AgentSpan span = activeSpan();
+        if (span != null) {
+          DECORATE.onPeerConnection(span, connection);
+        }
+        if (message != null) {
+          MessageProperties properties = message.getMessageProperties();
+          if (properties != null) {
+            InstrumentationContext.get(MessageProperties.class, InetSocketAddress.class)
+                .put(properties, connection);
+          }
+        }
+      }
       if (null != delivery) {
         ContextStore<Delivery, State> from =
             InstrumentationContext.get(Delivery.class, State.class);
@@ -56,6 +86,64 @@ public class BlockingQueueConsumerInstrumentation extends InstrumenterModule.Tra
           InstrumentationContext.get(Message.class, State.class).put(message, state);
         }
       }
+    }
+
+    public static InetSocketAddress extractConnection(Object consumer) {
+      Object channel = invokeNoArg(consumer, "getChannel");
+      if (channel == null) {
+        channel = readField(consumer, "channel");
+      }
+      if (channel == null) {
+        return null;
+      }
+      Object connection = invokeNoArg(channel, "getConnection");
+      if (connection == null) {
+        return null;
+      }
+      Integer port = (Integer) invokeNoArg(connection, "getPort");
+      Object address = invokeNoArg(connection, "getAddress");
+      if (address instanceof InetAddress) {
+        return new InetSocketAddress((InetAddress) address, port != null ? port : 0);
+      }
+      Object host = invokeNoArg(connection, "getHost");
+      if (host instanceof String) {
+        return InetSocketAddress.createUnresolved((String) host, port != null ? port : 0);
+      }
+      return null;
+    }
+
+    public static Object invokeNoArg(Object target, String methodName) {
+      if (target == null) {
+        return null;
+      }
+      Class<?> current = target.getClass();
+      while (current != null) {
+        try {
+          Method method = current.getDeclaredMethod(methodName);
+          method.setAccessible(true);
+          return method.invoke(target);
+        } catch (ReflectiveOperationException ignored) {
+        }
+        current = current.getSuperclass();
+      }
+      return null;
+    }
+
+    public static Object readField(Object target, String fieldName) {
+      if (target == null) {
+        return null;
+      }
+      Class<?> current = target.getClass();
+      while (current != null) {
+        try {
+          Field field = current.getDeclaredField(fieldName);
+          field.setAccessible(true);
+          return field.get(target);
+        } catch (ReflectiveOperationException ignored) {
+        }
+        current = current.getSuperclass();
+      }
+      return null;
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/src/test/groovy/SpringAmqpTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/src/test/groovy/SpringAmqpTest.groovy
@@ -1,3 +1,4 @@
+import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.agent.test.InstrumentationSpecification
 import datadog.trace.agent.test.utils.PortUtils
 import org.testcontainers.containers.RabbitMQContainer
@@ -71,11 +72,15 @@ class SpringAmqpTest extends InstrumentationSpecification {
           childOf(span(0))
           operationName "amqp.consume"
           resourceName "amqp.consume test-queue"
+          tags(false) {
+            "$Tags.PEER_HOSTNAME" MessagingRabbitMQApplication.hostName
+            "$Tags.PEER_PORT" MessagingRabbitMQApplication.port
+          }
         }
         span(2) {
           childOf(span(1))
           operationName "receive"
-          resourceName "Receiver.receiveMessage"
+          resourceName "r.Receiver.receiveMessage"
         }
       }
       trace(1) {


### PR DESCRIPTION
## Summary

This PR brings two messaging-side fixes into `guance`:

1. Restore Redis `split-by-host` service naming for Redisson clients and Lettuce cluster writes.
2. Enrich Spring Rabbit consumer spans with the active connection host and port so `amqp.consume` can retain broker host context.

## Background

Customer validation showed two gaps in the current Guance branch:

- `DD_TRACE_DB_CLIENT_SPLIT_BY_HOST=true` could work for single-node Redis clients, but it did not reliably rename Redis services in Redisson or Lettuce cluster mode.
- RabbitMQ consumer-side spans such as `amqp.consume` / `spring.consume` could miss host-related metadata, which made downstream host-based mapping impossible.

## Changes

### Redis

- Update Redisson 2.0.0 / 2.3.0 / 3.10.3 instrumentations to resolve the connection host from `InetSocketAddress`.
- Route Redis spans through the database client decorator path that applies `trace.db.client.split-by-host`.
- Populate peer host information explicitly so Redisson spans can participate in host-based service renaming.

### Lettuce cluster

- Update Lettuce 5 command handling to derive host and port from the live Netty channel remote address.
- Apply `split-by-host` service naming to cluster writes using the actual remote endpoint seen by the client.

### RabbitMQ consumer spans

- Extract the active channel connection address from Spring Rabbit `BlockingQueueConsumer`.
- Propagate `peer.hostname` and `peer.port` into the consumer span flow.
- Ensure the upper-level `amqp.consume` span can retain the connection host context.
- Add Spring Rabbit coverage for the new behavior.

## Scope

- Includes runtime code changes and the changelog update only.
- Excludes the previously drafted investigation / customer-facing markdown documents.

## Validation

```bash
./gradlew :dd-java-agent:instrumentation:lettuce:lettuce-5.0:compileJava \
  :dd-java-agent:instrumentation:redisson:redisson-3.10.3:compileJava \
  :dd-java-agent:instrumentation:spring:spring-rabbit-1.5:test \
  --tests SpringAmqpTest \
  -x :dd-java-agent:ddprof-lib:shadowJar \
  --no-build-cache
```

Build result: `BUILD SUCCESSFUL`

## Notes

- Redis `split-by-host` still reflects the host name observed by the client. Stable business aliases still need to come from the application connection target or a later mapping layer.
- RabbitMQ consumer host enrichment reflects the active connection endpoint used by the Spring Rabbit consumer path.
