### PR TITLE
Add SSE response stream span for Netty client

### DIFF
--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
@@ -73,6 +73,7 @@ public class NettyChannelPipelineInstrumentation extends InstrumenterModule.Trac
       // client helpers
       packageName + ".client.NettyHttpClientDecorator",
       packageName + ".client.NettyResponseInjectAdapter",
+      packageName + ".client.NettyClientResponseStream",
       packageName + ".client.HttpClientRequestTracingHandler",
       packageName + ".client.HttpClientResponseTracingHandler",
       packageName + ".client.HttpClientTracingHandler",

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.spanFromContext;
 import static datadog.trace.instrumentation.netty41.AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY;
+import static datadog.trace.instrumentation.netty41.AttributeKeys.CLIENT_RESPONSE_STREAM_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.netty41.AttributeKeys.CONTEXT_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator.DECORATE;
 
@@ -13,9 +14,12 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.Attribute;
 
 @ChannelHandler.Sharable
@@ -44,7 +48,13 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
                       .equals(((HttpResponse) msg).headers().get(HttpHeaderNames.UPGRADE)));
       if (finishSpan) {
         try (final AgentScope scope = activateSpan(span)) {
-          DECORATE.onResponse(span, (HttpResponse) msg);
+          final HttpResponse response = (HttpResponse) msg;
+          DECORATE.onResponse(span, response);
+          final NettyClientResponseStream stream =
+              NettyClientResponseStream.startIfSse(span, response);
+          if (stream != null) {
+            ctx.channel().attr(CLIENT_RESPONSE_STREAM_ATTRIBUTE_KEY).set(stream);
+          }
           DECORATE.beforeFinish(span);
           span.finish();
         }
@@ -53,6 +63,10 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
           ctx.channel().attr(CONTEXT_ATTRIBUTE_KEY).set(storedContext);
         }
       }
+    }
+
+    if (msg instanceof HttpObject) {
+      handleResponseStream(ctx, msg);
     }
 
     // We want the callback in the scope of the parent, not the client span
@@ -83,6 +97,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
         span.finish();
       }
     }
+    finishResponseStreamWithError(ctx, cause);
     // We want the callback in the scope of the parent, not the client span
     try (final AgentScope scope = activateSpan(parent)) {
       super.exceptionCaught(ctx, cause);
@@ -108,9 +123,45 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
         span.finish();
       }
     }
+    finishResponseStream(ctx);
     // We want the callback in the scope of the parent, not the client span
     try (final AgentScope scope = activateSpan(parent)) {
       super.channelInactive(ctx);
+    }
+  }
+
+  private static void handleResponseStream(final ChannelHandlerContext ctx, final Object msg) {
+    final NettyClientResponseStream stream = getResponseStream(ctx);
+    if (stream == null) {
+      return;
+    }
+    if (msg instanceof HttpContent) {
+      stream.onChunk();
+    }
+    if (msg instanceof LastHttpContent) {
+      finishResponseStream(ctx);
+    }
+  }
+
+  private static NettyClientResponseStream getResponseStream(final ChannelHandlerContext ctx) {
+    final Object stream = ctx.channel().attr(CLIENT_RESPONSE_STREAM_ATTRIBUTE_KEY).get();
+    return stream instanceof NettyClientResponseStream ? (NettyClientResponseStream) stream : null;
+  }
+
+  private static void finishResponseStream(final ChannelHandlerContext ctx) {
+    final NettyClientResponseStream stream = getResponseStream(ctx);
+    if (stream != null) {
+      ctx.channel().attr(CLIENT_RESPONSE_STREAM_ATTRIBUTE_KEY).remove();
+      stream.finish();
+    }
+  }
+
+  private static void finishResponseStreamWithError(
+      final ChannelHandlerContext ctx, final Throwable cause) {
+    final NettyClientResponseStream stream = getResponseStream(ctx);
+    if (stream != null) {
+      ctx.channel().attr(CLIENT_RESPONSE_STREAM_ATTRIBUTE_KEY).remove();
+      stream.finishWithError(cause);
     }
   }
 }

--- a/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyClientResponseStream.java
+++ b/dd-java-agent/instrumentation/netty/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyClientResponseStream.java
@@ -1,0 +1,76 @@
+package datadog.trace.instrumentation.netty41.client;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.COMPONENT;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_INTERNAL;
+import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator.NETTY_CLIENT;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponse;
+import java.util.concurrent.TimeUnit;
+
+public final class NettyClientResponseStream {
+  public static final CharSequence NETTY_CLIENT_STREAM =
+      UTF8BytesString.create("netty.client.stream");
+
+  private static final CharSequence SSE = UTF8BytesString.create("sse");
+
+  private final AgentSpan span;
+  private final long startTimeNano;
+  private long chunkCount;
+  private boolean firstChunkSeen;
+  private boolean finished;
+
+  private NettyClientResponseStream(final AgentSpan parentSpan) {
+    this.span = startSpan(NETTY_CLIENT.toString(), NETTY_CLIENT_STREAM);
+    this.span.setResourceName("SSE stream " + parentSpan.getResourceName());
+    this.span.setTag(COMPONENT, NETTY_CLIENT);
+    this.span.setTag(SPAN_KIND, SPAN_KIND_INTERNAL);
+    this.span.setTag("stream.type", SSE);
+    this.startTimeNano = System.nanoTime();
+  }
+
+  public static NettyClientResponseStream startIfSse(
+      final AgentSpan parentSpan, final HttpResponse response) {
+    final String contentType = response.headers().get(HttpHeaderNames.CONTENT_TYPE);
+    if (contentType == null || !isEventStream(contentType)) {
+      return null;
+    }
+    return new NettyClientResponseStream(parentSpan);
+  }
+
+  public void onChunk() {
+    if (finished) {
+      return;
+    }
+    chunkCount++;
+    if (!firstChunkSeen) {
+      firstChunkSeen = true;
+      span.setMetric(
+          "stream.first_chunk.ms",
+          TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNano));
+    }
+  }
+
+  public void finish() {
+    if (!finished) {
+      finished = true;
+      span.setMetric("stream.chunk_count", chunkCount);
+      span.finish();
+    }
+  }
+
+  public void finishWithError(final Throwable throwable) {
+    if (!finished) {
+      span.addThrowable(throwable);
+      finish();
+    }
+  }
+
+  private static boolean isEventStream(final String contentType) {
+    return contentType.regionMatches(true, 0, "text/event-stream", 0, "text/event-stream".length());
+  }
+}

--- a/dd-java-agent/instrumentation/netty/netty-common/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty/netty-common/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
@@ -23,6 +23,9 @@ public final class AttributeKeys {
   public static final AttributeKey<AgentSpan> CLIENT_PARENT_ATTRIBUTE_KEY =
       attributeKey("datadog.client.parent.span");
 
+  public static final AttributeKey<Object> CLIENT_RESPONSE_STREAM_ATTRIBUTE_KEY =
+      attributeKey("datadog.client.response.stream");
+
   public static final AttributeKey<AgentScope.Continuation>
       CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY =
           attributeKey("datadog.connect.parent.continuation");


### PR DESCRIPTION
## Summary
- add a Netty client response stream span for SSE responses
- keep the existing netty.client.request span as the response-header/request phase
- record SSE stream duration, first chunk latency, and Netty content chunk count
- mark the stream span as internal and name its resource with an SSE stream prefix for clearer waterfall display

## Verification
- ./gradlew :dd-java-agent:instrumentation:netty:netty-4.1:compileJava :dd-java-agent:instrumentation:netty:netty-4.1:classes
- ./gradlew :dd-java-agent:shadowJar -x :dd-java-agent:instrumentation:cics-9.1:extractCicsJars -x :dd-java-agent:instrumentation:cics-9.1:compileJava -x :dd-java-agent:instrumentation:cics-9.1:jar -x :dd-java-agent:instrumentation:spray-1.3:compileScala -x :dd-java-agent:instrumentation:weaver-0.9:compileScala
- validated with local Spring Boot SSE demo through DataKit 9529

Labels were not applied because this repository fork does not expose comp:/inst:/type: labels.
