### PR TITLE
Support package-level trace method configuration

### DIFF
--- a/dd-java-agent/instrumentation/datadog/tracing/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
+++ b/dd-java-agent/instrumentation/datadog/tracing/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
@@ -15,8 +15,12 @@ import net.bytebuddy.implementation.bytecode.assign.Assigner;
 
 public class TraceAdvice {
   private static final String DEFAULT_OPERATION_NAME = "trace.annotation";
+
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static AgentScope onEnter(@Advice.Origin final Method method,@Advice.AllArguments final Object[] args) {
+  public static AgentScope onEnter(
+      @Advice.Origin("#t") final String className,
+      @Advice.Origin final Method method,
+      @Advice.AllArguments final Object[] args) {
     final Trace traceAnnotation = method.getAnnotation(Trace.class);
     CharSequence operationName = traceAnnotation == null ? null : traceAnnotation.operationName();
 
@@ -28,33 +32,38 @@ public class TraceAdvice {
       }
     }
 
-    final AgentSpan span = startSpan("trace",operationName);
+    final AgentSpan span = startSpan("trace", operationName);
 
     Parameter[] parameters = method.getParameters();
     StringBuffer methodName = new StringBuffer(method.getName());
     methodName.append("(");
     Integer max_size = 1024;
-    if (parameters.length>0){
+    if (parameters.length > 0) {
       for (int i = 0; i < parameters.length; i++) {
-        if (args[i]==null){
-          span.setTag(parameters[i].getName(),"null");
-        }else {
+        if (args[i] == null) {
+          span.setTag(parameters[i].getName(), "null");
+        } else {
           String value = args[i].toString();
-          span.setTag(parameters[i].getName(), args[i].toString().substring(0,value.length()>=max_size?max_size:value.length()));
+          span.setTag(
+              parameters[i].getName(),
+              args[i]
+                  .toString()
+                  .substring(0, value.length() >= max_size ? max_size : value.length()));
         }
-        methodName.append(parameters[i].getType().getTypeName()).append(" ").append(parameters[i].getName());
-        if (i<parameters.length-1){
+        methodName
+            .append(parameters[i].getType().getTypeName())
+            .append(" ")
+            .append(parameters[i].getName());
+        if (i < parameters.length - 1) {
           methodName.append(",");
         }
       }
     }
     methodName.append(")");
-    span.setTag("method_name",methodName.toString());
+    span.setTag("method_name", methodName.toString());
     CharSequence resourceName = traceAnnotation == null ? null : traceAnnotation.resourceName();
     if (resourceName == null || resourceName.length() == 0) {
-      StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
-      String className = stackTraceElements[1].getClassName(); // 第一个元素是当前方法
-      resourceName = DECORATE.getMethodName(className)+"."+method.getName();
+      resourceName = DECORATE.getMethodName(className) + "." + method.getName();
     }
     span.setResourceName(resourceName);
     DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/datadog/tracing/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/datadog/tracing/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.trace_annotation;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasSuperType;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static java.util.Collections.emptyList;
@@ -39,10 +40,12 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(InstrumenterModule.class)
 public class TraceConfigInstrumentation extends InstrumenterModule.Tracing {
   private final Map<String, Set<String>> classMethodsToTrace;
+  private final Set<String> packagesToTrace;
 
   public TraceConfigInstrumentation() {
     super("trace", "trace-config");
     classMethodsToTrace = InstrumenterConfig.get().getTraceMethods();
+    packagesToTrace = InstrumenterConfig.get().getTraceMethodPackages();
   }
 
   @Override
@@ -54,7 +57,7 @@ public class TraceConfigInstrumentation extends InstrumenterModule.Tracing {
 
   @Override
   public List<Instrumenter> typeInstrumentations() {
-    if (classMethodsToTrace.isEmpty()) {
+    if (classMethodsToTrace.isEmpty() && packagesToTrace.isEmpty()) {
       return emptyList();
     }
     List<Instrumenter> typeInstrumentations = new ArrayList<>();
@@ -65,7 +68,24 @@ public class TraceConfigInstrumentation extends InstrumenterModule.Tracing {
         System.out.println("Instrumenting " + entry.getKey() + " with " + entry.getValue());
       }
     }
+    for (String packageName : packagesToTrace) {
+      List<String> integrationNames = singletonList("trace-config_" + packageName);
+      if (InstrumenterConfig.get().isIntegrationEnabled(integrationNames, true)) {
+        typeInstrumentations.add(new TracerPackageInstrumentation(packageName));
+      }
+    }
     return typeInstrumentations;
+  }
+
+  private static ElementMatcher<MethodDescription> tracedMethodFilter() {
+    return not(
+        isHashCode()
+            .or(isEquals())
+            .or(isToString())
+            .or(isFinalizer())
+            .or(isGetter())
+            .or(isSetter())
+            .or(isSynthetic()));
   }
 
   // Not Using AutoService to hook up this instrumentation
@@ -96,20 +116,37 @@ public class TraceConfigInstrumentation extends InstrumenterModule.Tracing {
       }
       ElementMatcher<MethodDescription> methodFilter;
       if (hasWildcard) {
-        methodFilter =
-            not(
-                isHashCode()
-                    .or(isEquals())
-                    .or(isToString())
-                    .or(isFinalizer())
-                    .or(isGetter())
-                    .or(isSetter())
-                    .or(isSynthetic()));
+        methodFilter = tracedMethodFilter();
       } else {
         methodFilter = namedOneOf(methodNames);
       }
       transformer.applyAdvice(
           isMethod().and(methodFilter),
+          "datadog.trace.instrumentation.trace_annotation.TraceAdvice");
+    }
+  }
+
+  public static class TracerPackageInstrumentation implements ForTypeHierarchy, HasMethodAdvice {
+    private final String packagePrefix;
+
+    public TracerPackageInstrumentation(final String packageName) {
+      this.packagePrefix = packageName.endsWith(".") ? packageName : packageName + ".";
+    }
+
+    @Override
+    public String hierarchyMarkerType() {
+      return null;
+    }
+
+    @Override
+    public ElementMatcher<TypeDescription> hierarchyMatcher() {
+      return nameStartsWith(packagePrefix);
+    }
+
+    @Override
+    public void methodAdvice(MethodTransformer transformer) {
+      transformer.applyAdvice(
+          isMethod().and(tracedMethodFilter()),
           "datadog.trace.instrumentation.trace_annotation.TraceAdvice");
     }
   }

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -7961,6 +7961,22 @@
         "aliases": []
       }
     ],
+    "DD_TRACE_METHOD_FILE": [
+      {
+        "version": "A",
+        "type": "string",
+        "default": null,
+        "aliases": []
+      }
+    ],
+    "DD_TRACE_METHOD_PACKAGES": [
+      {
+        "version": "A",
+        "type": "string",
+        "default": null,
+        "aliases": []
+      }
+    ],
     "DD_TRACE_NATIVE_METHODS": [
       {
         "version": "A",


### PR DESCRIPTION
## Summary
- Support `DD_TRACE_METHOD_PACKAGES` through the existing trace-config instrumentation path.
- Add package-prefix type matching that reuses `TraceAdvice` instead of requiring a separate all-method instrumentation module.
- Use Byte Buddy origin class name for generated resource names.
- Register `DD_TRACE_METHOD_FILE` and `DD_TRACE_METHOD_PACKAGES` in supported configurations metadata.

## Verification
- `./gradlew :dd-java-agent:instrumentation:datadog:tracing:trace-annotation:compileJava`
- `./gradlew :dd-java-agent:instrumentation:datadog:tracing:trace-annotation:test` was attempted; it is currently blocked by an existing unsupported config metadata issue for `DD_HTTP_ERROR_ENABLED`.
- `./gradlew :dd-java-agent:shadowJar --stacktrace` was attempted; it is currently blocked by missing dependency `com.bes.enterprise:bes-lite-spring-boot-starter:11.5.0` for `:dd-java-agent:instrumentation:bes:bes-11.0`.
