### PR TITLE
Support GWT RPC request body tagging

### DIFF
--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/latestDepTest/groovy/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilterForkedTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/latestDepTest/groovy/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilterForkedTest.groovy
@@ -50,4 +50,30 @@ class HandlerMappingResourceNameFilterForkedTest extends InstrumentationSpecific
     where:
     url << ["/single", "/not-found"]
   }
+
+  def "test filter tags request_body for gwt rpc content type"() {
+    given:
+    injectSysConfig('dd.trace.request.body.enabled', 'true')
+    def payload = '7|0|4|https://example.com/app/|com.foo.Service|doThing|1|2|3|4|'
+    def request = new MockHttpServletRequest("POST", "/single")
+    request.setCharacterEncoding("UTF-8")
+    request.setContentType("text/x-gwt-rpc; charset=UTF-8")
+    request.setContent(payload.getBytes("UTF-8"))
+    def response = Mock(HttpServletResponse)
+    def filterChain = Mock(FilterChain) {
+      1 * doFilter(_, _) >> { req, resp ->
+        req.reader.text
+      }
+    }
+
+    when:
+    runUnderTrace("test-servlet", {
+      request.setAttribute(DD_CONTEXT_ATTRIBUTE, activeSpan().context())
+      filter.doFilterInternal(request, response, filterChain)
+    })
+    TEST_WRITER.waitForTraces(1)
+
+    then:
+    TEST_WRITER.flatten().find { it.operationName == 'test-servlet' }.getTag('request_body') == payload
+  }
 }

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
@@ -10,9 +10,12 @@ import datadog.trace.api.Config;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -109,9 +112,8 @@ public class HandlerMappingResourceNameFilter extends OncePerRequestFilter imple
 
       if (Config.get().isTracerRequestBodyEnabled()
           && "POST".equalsIgnoreCase(methodType)
-          && contextType != null
-          && (contextType.contains("application/json"))) {
-        span.setTag("request_body", new String(requestWrapper.getContentAsByteArray()));
+          && isSupportedRequestBodyContentType(contextType)) {
+        span.setTag("request_body", decodeRequestBody(requestWrapper));
       }
       int dataLength = data==null?0:data.length;
       if (log.isDebugEnabled()) {
@@ -216,6 +218,27 @@ public class HandlerMappingResourceNameFilter extends OncePerRequestFilter imple
 
   private boolean isEmpty(String str) {
     return str == null || str.length() == 0;
+  }
+
+  private boolean isSupportedRequestBodyContentType(String contentType) {
+    if (contentType == null) {
+      return false;
+    }
+    String normalizedContentType = contentType.toLowerCase(Locale.ROOT);
+    return normalizedContentType.contains("application/json")
+        || normalizedContentType.contains("text/x-gwt-rpc");
+  }
+
+  private String decodeRequestBody(ContentCachingRequestWrapper requestWrapper) {
+    Charset charset = StandardCharsets.UTF_8;
+    String encoding = requestWrapper.getCharacterEncoding();
+    if (encoding != null) {
+      try {
+        charset = Charset.forName(encoding);
+      } catch (IllegalArgumentException ignored) {
+      }
+    }
+    return new String(requestWrapper.getContentAsByteArray(), charset);
   }
 
   private void buildHeaderTags(AgentSpan span,final HttpServletRequest request, final HttpServletResponse response) {

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilterForkedTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilterForkedTest.groovy
@@ -50,4 +50,30 @@ class HandlerMappingResourceNameFilterForkedTest extends InstrumentationSpecific
     where:
     url << ["/single", "/not-found"]
   }
+
+  def "test filter tags request_body for gwt rpc content type"() {
+    given:
+    injectSysConfig('dd.trace.request.body.enabled', 'true')
+    def payload = '7|0|4|https://example.com/app/|com.foo.Service|doThing|1|2|3|4|'
+    def request = new MockHttpServletRequest("POST", "/single")
+    request.setCharacterEncoding("UTF-8")
+    request.setContentType("text/x-gwt-rpc; charset=UTF-8")
+    request.setContent(payload.getBytes("UTF-8"))
+    def response = Mock(HttpServletResponse)
+    def filterChain = Mock(FilterChain) {
+      1 * doFilter(_, _) >> { req, resp ->
+        req.reader.text
+      }
+    }
+
+    when:
+    runUnderTrace("test-servlet", {
+      request.setAttribute(DD_CONTEXT_ATTRIBUTE, activeSpan().context())
+      filter.doFilterInternal(request, response, filterChain)
+    })
+    TEST_WRITER.waitForTraces(1)
+
+    then:
+    TEST_WRITER.flatten().find { it.operationName == 'test-servlet' }.getTag('request_body') == payload
+  }
 }

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandlerMappingResourceNameFilter.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandlerMappingResourceNameFilter.java
@@ -15,9 +15,12 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,9 +117,8 @@ public class HandlerMappingResourceNameFilter extends OncePerRequestFilter imple
 
       if (Config.get().isTracerRequestBodyEnabled()
           && "POST".equalsIgnoreCase(methodType)
-          && contextType != null
-          && (contextType.contains("application/json"))) {
-        span.setTag("request_body", new String(requestWrapper.getContentAsByteArray()));
+          && isSupportedRequestBodyContentType(contextType)) {
+        span.setTag("request_body", decodeRequestBody(requestWrapper));
       }
       int dataLength = data==null?0:data.length;
       log.debug(
@@ -152,6 +154,27 @@ public class HandlerMappingResourceNameFilter extends OncePerRequestFilter imple
   }
   private boolean isEmpty(String str) {
     return str == null || str.length() == 0;
+  }
+
+  private boolean isSupportedRequestBodyContentType(String contentType) {
+    if (contentType == null) {
+      return false;
+    }
+    String normalizedContentType = contentType.toLowerCase(Locale.ROOT);
+    return normalizedContentType.contains("application/json")
+        || normalizedContentType.contains("text/x-gwt-rpc");
+  }
+
+  private String decodeRequestBody(ContentCachingRequestWrapper requestWrapper) {
+    Charset charset = StandardCharsets.UTF_8;
+    String encoding = requestWrapper.getCharacterEncoding();
+    if (encoding != null) {
+      try {
+        charset = Charset.forName(encoding);
+      } catch (IllegalArgumentException ignored) {
+      }
+    }
+    return new String(requestWrapper.getContentAsByteArray(), charset);
   }
 
   public static boolean matchPath(String requestPath, String[] patterns) {


### PR DESCRIPTION
## Summary
- allow `request_body` tagging for `text/x-gwt-rpc` requests in Spring WebMVC filters
- decode request body using the request character encoding with UTF-8 fallback
- add forked coverage for the GWT RPC request body tagging path

## Testing
- `./gradlew :dd-java-agent:instrumentation:spring:spring-webmvc:spring-webmvc-6.0:compileMain_java17Java`
- `./gradlew :dd-java-agent:instrumentation:spring:spring-webmvc:spring-webmvc-3.1:forkedTest --tests datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilterForkedTest` currently fails during test initialization because of existing unsupported config `DD_HTTP_ERROR_ENABLED`
- `./gradlew :dd-java-agent:instrumentation:spring:spring-webmvc:spring-webmvc-3.1:latestDepForkedTest --tests datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilterForkedTest` currently fails for the same reason