### PR TITLE
Report raw JVM runtime metrics via StatsD

### DIFF
--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -148,6 +148,11 @@ public class JMXFetch {
     final AppConfig appConfig = configBuilder.build();
 
     if (!otlpRuntimeMetricsEnabled) {
+      JvmGcStatsDReporter.start(
+          statsd,
+          globalTags,
+          appConfig.getCheckPeriod(),
+          () -> !appConfig.getExitWatcher().shouldExit());
       JvmThreadCountStatsDReporter.start(
           statsd,
           globalTags,

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -147,6 +147,14 @@ public class JMXFetch {
 
     final AppConfig appConfig = configBuilder.build();
 
+    if (!otlpRuntimeMetricsEnabled) {
+      JvmThreadCountStatsDReporter.start(
+          statsd,
+          globalTags,
+          appConfig.getCheckPeriod(),
+          () -> !appConfig.getExitWatcher().shouldExit());
+    }
+
     final Thread thread =
         newAgentThread(
             JMX_COLLECTOR,

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JvmGcStatsDReporter.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JvmGcStatsDReporter.java
@@ -4,32 +4,50 @@ import static datadog.trace.util.AgentThreadFactory.AgentThread.JMX_COLLECTOR;
 import static datadog.trace.util.AgentThreadFactory.newAgentThread;
 
 import datadog.metrics.api.statsd.StatsDClient;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
 import java.util.Arrays;
-import java.util.Locale;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
 
-final class JvmThreadCountStatsDReporter implements Runnable {
-  static final String METRIC_NAME = "jvm.thread.count";
+final class JvmGcStatsDReporter implements Runnable {
+  static final String COLLECTION_COUNT_METRIC = "jvm.gc.collection_count";
+  static final String COLLECTION_TIME_METRIC = "jvm.gc.collection_time";
 
   private static final long MIN_CHECK_PERIOD_MILLIS = 1_000L;
-  private static final String THREAD_DAEMON_TAG = "jvm.thread.daemon:";
-  private static final String THREAD_STATE_TAG = "jvm.thread.state:";
+  private static final String GC_TAG = "gc:";
 
   private final StatsDClient statsd;
   private final String[] commonTags;
   private final BooleanSupplier shouldCollect;
   private final long checkPeriodMillis;
+  private final List<GarbageCollectorMXBean> gcBeans;
 
-  JvmThreadCountStatsDReporter(
+  JvmGcStatsDReporter(
       StatsDClient statsd,
       Map<String, String> commonTags,
       long checkPeriodMillis,
       BooleanSupplier shouldCollect) {
+    this(
+        statsd,
+        commonTags,
+        checkPeriodMillis,
+        shouldCollect,
+        ManagementFactory.getGarbageCollectorMXBeans());
+  }
+
+  JvmGcStatsDReporter(
+      StatsDClient statsd,
+      Map<String, String> commonTags,
+      long checkPeriodMillis,
+      BooleanSupplier shouldCollect,
+      List<GarbageCollectorMXBean> gcBeans) {
     this.statsd = statsd;
     this.commonTags = toTagArray(commonTags);
     this.checkPeriodMillis = Math.max(MIN_CHECK_PERIOD_MILLIS, checkPeriodMillis);
     this.shouldCollect = shouldCollect;
+    this.gcBeans = gcBeans;
   }
 
   static void start(
@@ -40,8 +58,8 @@ final class JvmThreadCountStatsDReporter implements Runnable {
     Thread thread =
         newAgentThread(
             JMX_COLLECTOR,
-            "-thread-count",
-            new JvmThreadCountStatsDReporter(statsd, commonTags, checkPeriodMillis, shouldCollect),
+            "-gc",
+            new JvmGcStatsDReporter(statsd, commonTags, checkPeriodMillis, shouldCollect),
             true);
     thread.start();
   }
@@ -62,14 +80,22 @@ final class JvmThreadCountStatsDReporter implements Runnable {
   }
 
   void reportOnce() {
-    JvmThreadCountCollector.collect(
-        (daemon, state, count) -> statsd.gauge(METRIC_NAME, count, tagsFor(daemon, state)));
+    for (GarbageCollectorMXBean gcBean : gcBeans) {
+      String[] tags = tagsFor(gcBean.getName());
+      long collectionCount = gcBean.getCollectionCount();
+      if (collectionCount >= 0) {
+        statsd.gauge(COLLECTION_COUNT_METRIC, collectionCount, tags);
+      }
+      long collectionTime = gcBean.getCollectionTime();
+      if (collectionTime >= 0) {
+        statsd.gauge(COLLECTION_TIME_METRIC, collectionTime, tags);
+      }
+    }
   }
 
-  private String[] tagsFor(boolean daemon, Thread.State state) {
-    String[] tags = Arrays.copyOf(commonTags, commonTags.length + 2);
-    tags[commonTags.length] = THREAD_DAEMON_TAG + daemon;
-    tags[commonTags.length + 1] = THREAD_STATE_TAG + state.name().toLowerCase(Locale.ROOT);
+  private String[] tagsFor(String gcName) {
+    String[] tags = Arrays.copyOf(commonTags, commonTags.length + 1);
+    tags[commonTags.length] = GC_TAG + gcName;
     return tags;
   }
 

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JvmOtlpRuntimeMetrics.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JvmOtlpRuntimeMetrics.java
@@ -278,7 +278,6 @@ public final class JvmOtlpRuntimeMetrics {
         THREAD_COUNT_COLLECTOR);
   }
 
-
   /**
    * jvm.class.loaded (Counter), jvm.class.unloaded (Counter), jvm.class.count (UpDownCounter) — all
    * Stable per spec.

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JvmOtlpRuntimeMetrics.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JvmOtlpRuntimeMetrics.java
@@ -17,9 +17,6 @@ import datadog.trace.bootstrap.otel.metrics.OtelInstrumentType;
 import datadog.trace.bootstrap.otel.metrics.data.OtelMetricRegistry;
 import datadog.trace.bootstrap.otel.metrics.data.OtelMetricStorage;
 import datadog.trace.bootstrap.otel.metrics.data.OtelRunnableObservable;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.GarbageCollectorMXBean;
@@ -27,13 +24,9 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
-import java.lang.management.ThreadInfo;
-import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
-import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -89,42 +82,15 @@ public final class JvmOtlpRuntimeMetrics {
     return result;
   }
 
-  /**
-   * MethodHandle for {@code ThreadInfo#isDaemon()}: non-null on Java 9+, null on Java 8. Doubles as
-   * the Java-version probe since this code is compiled against Java 8 and cannot reference the
-   * symbol directly.
-   */
-  private static final MethodHandle THREAD_INFO_IS_DAEMON = resolveThreadInfoIsDaemon();
-
-  private static final ThreadMXBean THREAD_BEAN = ManagementFactory.getThreadMXBean();
-
-  /**
-   * jvm.thread.count collector, chosen once at class load. Java 9+ uses {@link
-   * ThreadMXBean#getThreadInfo(long[])} (the single-arg overload omits stack-trace capture); Java 8
-   * (and GraalVM native image, where ThreadMXBean is unsupported) walks the root {@link
-   * ThreadGroup}. Avoids {@link Thread#getAllStackTraces()}, which forces a safepoint and allocates
-   * a {@code StackTraceElement[]} per thread on every poll.
-   */
   private static final Consumer<OtelMetricStorage> THREAD_COUNT_COLLECTOR =
-      chooseThreadCountCollector();
-
-  private static MethodHandle resolveThreadInfoIsDaemon() {
-    try {
-      return MethodHandles.publicLookup()
-          .findVirtual(ThreadInfo.class, "isDaemon", MethodType.methodType(boolean.class));
-    } catch (NoSuchMethodException | IllegalAccessException e) {
-      return null; // Java 8 — fall back to ThreadGroup walk
-    }
-  }
-
-  private static Consumer<OtelMetricStorage> chooseThreadCountCollector() {
-    boolean isJava9OrNewer = THREAD_INFO_IS_DAEMON != null;
-    boolean isNativeImage = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
-    if (isJava9OrNewer && !isNativeImage) {
-      return JvmOtlpRuntimeMetrics::collectThreadCountsViaThreadMXBean;
-    }
-    return JvmOtlpRuntimeMetrics::collectThreadCountsViaThreadGroup;
-  }
+      storage ->
+          JvmThreadCountCollector.collect(
+              (daemon, state, count) ->
+                  storage.recordLong(
+                      count,
+                      daemon
+                          ? DAEMON_THREAD_STATE_ATTRS[state.ordinal()]
+                          : NON_DAEMON_THREAD_STATE_ATTRS[state.ordinal()]));
 
   /** Explicit bucket advice for jvm.gc.duration in seconds (matches OTel runtime-telemetry). */
   private static final List<Double> GC_DURATION_BUCKETS = Arrays.asList(0.01, 0.1, 1.0, 10.0);
@@ -312,79 +278,6 @@ public final class JvmOtlpRuntimeMetrics {
         THREAD_COUNT_COLLECTOR);
   }
 
-  /**
-   * Java 9+ path. Enumerates threads via {@link ThreadMXBean#getThreadInfo(long[])}; the single-arg
-   * overload omits stack-trace capture, avoiding the safepoint and per-frame allocation incurred by
-   * {@link Thread#getAllStackTraces()}.
-   */
-  private static void collectThreadCountsViaThreadMXBean(OtelMetricStorage storage) {
-    Map<Thread.State, long[]> daemonCounts = new EnumMap<>(Thread.State.class);
-    Map<Thread.State, long[]> nonDaemonCounts = new EnumMap<>(Thread.State.class);
-    long[] ids = THREAD_BEAN.getAllThreadIds();
-    for (ThreadInfo info : THREAD_BEAN.getThreadInfo(ids)) {
-      if (info == null) {
-        continue; // thread terminated between getAllThreadIds and getThreadInfo
-      }
-      Map<Thread.State, long[]> bucket = threadInfoIsDaemon(info) ? daemonCounts : nonDaemonCounts;
-      bucket.computeIfAbsent(info.getThreadState(), k -> new long[1])[0]++;
-    }
-    recordThreadStateCounts(storage, daemonCounts, DAEMON_THREAD_STATE_ATTRS);
-    recordThreadStateCounts(storage, nonDaemonCounts, NON_DAEMON_THREAD_STATE_ATTRS);
-  }
-
-  /**
-   * Java 8 / GraalVM fallback. Walks the root {@link ThreadGroup} because {@code
-   * ThreadInfo.isDaemon()} was added in Java 9 and {@link ThreadMXBean} is not supported on GraalVM
-   * native images.
-   */
-  private static void collectThreadCountsViaThreadGroup(OtelMetricStorage storage) {
-    Map<Thread.State, long[]> daemonCounts = new EnumMap<>(Thread.State.class);
-    Map<Thread.State, long[]> nonDaemonCounts = new EnumMap<>(Thread.State.class);
-    for (Thread thread : enumerateAllThreads()) {
-      Map<Thread.State, long[]> bucket = thread.isDaemon() ? daemonCounts : nonDaemonCounts;
-      bucket.computeIfAbsent(thread.getState(), k -> new long[1])[0]++;
-    }
-    recordThreadStateCounts(storage, daemonCounts, DAEMON_THREAD_STATE_ATTRS);
-    recordThreadStateCounts(storage, nonDaemonCounts, NON_DAEMON_THREAD_STATE_ATTRS);
-  }
-
-  /** Invokes {@code ThreadInfo#isDaemon()} via {@link #THREAD_INFO_IS_DAEMON} (Java 9+ only). */
-  private static boolean threadInfoIsDaemon(ThreadInfo info) {
-    try {
-      return (boolean) THREAD_INFO_IS_DAEMON.invoke(info);
-    } catch (Throwable t) {
-      throw new IllegalStateException("Unexpected error invoking ThreadInfo#isDaemon()", t);
-    }
-  }
-
-  /**
-   * Walks the root {@link ThreadGroup} and returns a snapshot of active threads. Allocates a
-   * slightly oversized buffer to absorb threads created between {@code activeCount()} and {@code
-   * enumerate()}; if the buffer is still too small the returned array may be truncated.
-   */
-  private static Thread[] enumerateAllThreads() {
-    ThreadGroup group = Thread.currentThread().getThreadGroup();
-    // ThreadGroup.enumerate() recursively descends through children by default, so enumerating from
-    // the root gives every live thread in the JVM.
-    while (group.getParent() != null) {
-      group = group.getParent();
-    }
-    Thread[] buffer = new Thread[group.activeCount() + 10];
-    int n = group.enumerate(buffer);
-    if (n == buffer.length) {
-      return buffer;
-    }
-    Thread[] trimmed = new Thread[n];
-    System.arraycopy(buffer, 0, trimmed, 0, n);
-    return trimmed;
-  }
-
-  private static void recordThreadStateCounts(
-      OtelMetricStorage storage, Map<Thread.State, long[]> counts, Attributes[] attrsByState) {
-    for (Map.Entry<Thread.State, long[]> entry : counts.entrySet()) {
-      storage.recordLong(entry.getValue()[0], attrsByState[entry.getKey().ordinal()]);
-    }
-  }
 
   /**
    * jvm.class.loaded (Counter), jvm.class.unloaded (Counter), jvm.class.count (UpDownCounter) — all

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JvmThreadCountCollector.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JvmThreadCountCollector.java
@@ -1,0 +1,102 @@
+package datadog.trace.agent.jmxfetch;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+final class JvmThreadCountCollector {
+  interface ThreadCountConsumer {
+    void accept(boolean daemon, Thread.State state, long count);
+  }
+
+  private static final MethodHandle THREAD_INFO_IS_DAEMON = resolveThreadInfoIsDaemon();
+  private static final ThreadMXBean THREAD_BEAN = ManagementFactory.getThreadMXBean();
+  private static final Consumer<ThreadCountConsumer> THREAD_COUNT_COLLECTOR =
+      chooseThreadCountCollector();
+
+  private JvmThreadCountCollector() {}
+
+  static void collect(ThreadCountConsumer consumer) {
+    THREAD_COUNT_COLLECTOR.accept(consumer);
+  }
+
+  private static MethodHandle resolveThreadInfoIsDaemon() {
+    try {
+      return MethodHandles.publicLookup()
+          .findVirtual(ThreadInfo.class, "isDaemon", MethodType.methodType(boolean.class));
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      return null;
+    }
+  }
+
+  private static Consumer<ThreadCountConsumer> chooseThreadCountCollector() {
+    boolean isJava9OrNewer = THREAD_INFO_IS_DAEMON != null;
+    boolean isNativeImage = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+    if (isJava9OrNewer && !isNativeImage) {
+      return JvmThreadCountCollector::collectThreadCountsViaThreadMXBean;
+    }
+    return JvmThreadCountCollector::collectThreadCountsViaThreadGroup;
+  }
+
+  private static void collectThreadCountsViaThreadMXBean(ThreadCountConsumer consumer) {
+    Map<Thread.State, long[]> daemonCounts = new EnumMap<>(Thread.State.class);
+    Map<Thread.State, long[]> nonDaemonCounts = new EnumMap<>(Thread.State.class);
+    long[] ids = THREAD_BEAN.getAllThreadIds();
+    for (ThreadInfo info : THREAD_BEAN.getThreadInfo(ids)) {
+      if (info == null) {
+        continue;
+      }
+      Map<Thread.State, long[]> bucket = threadInfoIsDaemon(info) ? daemonCounts : nonDaemonCounts;
+      bucket.computeIfAbsent(info.getThreadState(), k -> new long[1])[0]++;
+    }
+    recordThreadStateCounts(consumer, true, daemonCounts);
+    recordThreadStateCounts(consumer, false, nonDaemonCounts);
+  }
+
+  private static void collectThreadCountsViaThreadGroup(ThreadCountConsumer consumer) {
+    Map<Thread.State, long[]> daemonCounts = new EnumMap<>(Thread.State.class);
+    Map<Thread.State, long[]> nonDaemonCounts = new EnumMap<>(Thread.State.class);
+    for (Thread thread : enumerateAllThreads()) {
+      Map<Thread.State, long[]> bucket = thread.isDaemon() ? daemonCounts : nonDaemonCounts;
+      bucket.computeIfAbsent(thread.getState(), k -> new long[1])[0]++;
+    }
+    recordThreadStateCounts(consumer, true, daemonCounts);
+    recordThreadStateCounts(consumer, false, nonDaemonCounts);
+  }
+
+  private static boolean threadInfoIsDaemon(ThreadInfo info) {
+    try {
+      return (boolean) THREAD_INFO_IS_DAEMON.invoke(info);
+    } catch (Throwable t) {
+      throw new IllegalStateException("Unexpected error invoking ThreadInfo#isDaemon()", t);
+    }
+  }
+
+  private static Thread[] enumerateAllThreads() {
+    ThreadGroup group = Thread.currentThread().getThreadGroup();
+    while (group.getParent() != null) {
+      group = group.getParent();
+    }
+    Thread[] buffer = new Thread[group.activeCount() + 10];
+    int n = group.enumerate(buffer);
+    if (n == buffer.length) {
+      return buffer;
+    }
+    Thread[] trimmed = new Thread[n];
+    System.arraycopy(buffer, 0, trimmed, 0, n);
+    return trimmed;
+  }
+
+  private static void recordThreadStateCounts(
+      ThreadCountConsumer consumer, boolean daemon, Map<Thread.State, long[]> counts) {
+    for (Map.Entry<Thread.State, long[]> entry : counts.entrySet()) {
+      consumer.accept(daemon, entry.getKey(), entry.getValue()[0]);
+    }
+  }
+}

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JvmThreadCountStatsDReporter.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JvmThreadCountStatsDReporter.java
@@ -1,0 +1,83 @@
+package datadog.trace.agent.jmxfetch;
+
+import static datadog.trace.util.AgentThreadFactory.AgentThread.JMX_COLLECTOR;
+import static datadog.trace.util.AgentThreadFactory.newAgentThread;
+
+import datadog.metrics.api.statsd.StatsDClient;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
+
+final class JvmThreadCountStatsDReporter implements Runnable {
+  static final String METRIC_NAME = "jvm.thread.count";
+
+  private static final long MIN_CHECK_PERIOD_MILLIS = 1_000L;
+  private static final String THREAD_DAEMON_TAG = "jvm.thread.daemon:";
+  private static final String THREAD_STATE_TAG = "jvm.thread.state:";
+
+  private final StatsDClient statsd;
+  private final String[] commonTags;
+  private final BooleanSupplier shouldCollect;
+  private final long checkPeriodMillis;
+
+  JvmThreadCountStatsDReporter(
+      StatsDClient statsd,
+      Map<String, String> commonTags,
+      long checkPeriodMillis,
+      BooleanSupplier shouldCollect) {
+    this.statsd = statsd;
+    this.commonTags = toTagArray(commonTags);
+    this.checkPeriodMillis = Math.max(MIN_CHECK_PERIOD_MILLIS, checkPeriodMillis);
+    this.shouldCollect = shouldCollect;
+  }
+
+  static void start(
+      StatsDClient statsd,
+      Map<String, String> commonTags,
+      long checkPeriodMillis,
+      BooleanSupplier shouldCollect) {
+    Thread thread =
+        newAgentThread(
+            JMX_COLLECTOR,
+            "-thread-count",
+            new JvmThreadCountStatsDReporter(
+                statsd, commonTags, checkPeriodMillis, shouldCollect),
+            true);
+    thread.start();
+  }
+
+  @Override
+  public void run() {
+    while (!Thread.currentThread().isInterrupted()) {
+      if (shouldCollect.getAsBoolean()) {
+        reportOnce();
+      }
+      try {
+        Thread.sleep(checkPeriodMillis);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+  }
+
+  void reportOnce() {
+    JvmThreadCountCollector.collect(
+        (daemon, state, count) -> statsd.gauge(METRIC_NAME, count, tagsFor(daemon, state)));
+  }
+
+  private String[] tagsFor(boolean daemon, Thread.State state) {
+    String[] tags = Arrays.copyOf(commonTags, commonTags.length + 2);
+    tags[commonTags.length] = THREAD_DAEMON_TAG + daemon;
+    tags[commonTags.length + 1] = THREAD_STATE_TAG + state.name().toLowerCase(Locale.ROOT);
+    return tags;
+  }
+
+  private static String[] toTagArray(Map<String, String> commonTags) {
+    return commonTags.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .map(entry -> entry.getKey() + ":" + entry.getValue())
+        .toArray(String[]::new);
+  }
+}

--- a/dd-java-agent/agent-jmxfetch/src/test/java/datadog/trace/agent/jmxfetch/JvmGcStatsDReporterTest.java
+++ b/dd-java-agent/agent-jmxfetch/src/test/java/datadog/trace/agent/jmxfetch/JvmGcStatsDReporterTest.java
@@ -1,0 +1,186 @@
+package datadog.trace.agent.jmxfetch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.metrics.api.statsd.StatsDClient;
+import java.lang.management.GarbageCollectorMXBean;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.management.ObjectName;
+import org.junit.jupiter.api.Test;
+
+class JvmGcStatsDReporterTest {
+
+  @Test
+  void reportOnceEmitsRawGcBeanValuesWithGcTag() {
+    CapturingStatsDClient statsd = new CapturingStatsDClient();
+    Map<String, String> commonTags = new LinkedHashMap<>();
+    commonTags.put("service", "test-service");
+    commonTags.put("env", "test");
+
+    new JvmGcStatsDReporter(
+            statsd,
+            commonTags,
+            1_000L,
+            () -> true,
+            Collections.singletonList(new TestGarbageCollectorMXBean()))
+        .reportOnce();
+
+    assertEquals(2, statsd.gauges.size());
+    Gauge countGauge = statsd.gauges.get(0);
+    assertEquals(JvmGcStatsDReporter.COLLECTION_COUNT_METRIC, countGauge.metricName);
+    assertEquals(42, countGauge.value);
+    assertContainsPrefix(countGauge.tags, "gc:test-gc");
+    assertContainsPrefix(countGauge.tags, "service:test-service");
+    assertContainsPrefix(countGauge.tags, "env:test");
+
+    Gauge timeGauge = statsd.gauges.get(1);
+    assertEquals(JvmGcStatsDReporter.COLLECTION_TIME_METRIC, timeGauge.metricName);
+    assertEquals(1_234, timeGauge.value);
+    assertContainsPrefix(timeGauge.tags, "gc:test-gc");
+    assertContainsPrefix(timeGauge.tags, "service:test-service");
+    assertContainsPrefix(timeGauge.tags, "env:test");
+  }
+
+  @Test
+  void reportOnceSkipsUnavailableGcBeanValues() {
+    CapturingStatsDClient statsd = new CapturingStatsDClient();
+
+    new JvmGcStatsDReporter(
+            statsd,
+            Collections.emptyMap(),
+            1_000L,
+            () -> true,
+            Collections.singletonList(new UnavailableGarbageCollectorMXBean()))
+        .reportOnce();
+
+    assertTrue(statsd.gauges.isEmpty());
+  }
+
+  @Test
+  void reportOnceUsesJvmGcBeans() {
+    CapturingStatsDClient statsd = new CapturingStatsDClient();
+
+    new JvmGcStatsDReporter(statsd, Collections.emptyMap(), 1_000L, () -> true).reportOnce();
+
+    assertFalse(statsd.gauges.isEmpty(), "Expected at least one GC MXBean gauge emission");
+    for (Gauge gauge : statsd.gauges) {
+      assertContainsPrefix(gauge.tags, "gc:");
+    }
+  }
+
+  private static void assertContainsPrefix(String[] tags, String expectedPrefix) {
+    for (String tag : tags) {
+      if (tag.startsWith(expectedPrefix)) {
+        return;
+      }
+    }
+    throw new AssertionError("Missing tag prefix " + expectedPrefix);
+  }
+
+  private static class TestGarbageCollectorMXBean implements GarbageCollectorMXBean {
+    @Override
+    public String getName() {
+      return "test-gc";
+    }
+
+    @Override
+    public long getCollectionCount() {
+      return 42;
+    }
+
+    @Override
+    public long getCollectionTime() {
+      return 1_234;
+    }
+
+    @Override
+    public String[] getMemoryPoolNames() {
+      return new String[0];
+    }
+
+    @Override
+    public boolean isValid() {
+      return true;
+    }
+
+    @Override
+    public ObjectName getObjectName() {
+      return null;
+    }
+  }
+
+  private static final class UnavailableGarbageCollectorMXBean extends TestGarbageCollectorMXBean {
+    @Override
+    public long getCollectionCount() {
+      return -1;
+    }
+
+    @Override
+    public long getCollectionTime() {
+      return -1;
+    }
+  }
+
+  private static final class Gauge {
+    private final String metricName;
+    private final long value;
+    private final String[] tags;
+
+    private Gauge(String metricName, long value, String[] tags) {
+      this.metricName = metricName;
+      this.value = value;
+      this.tags = tags;
+    }
+  }
+
+  private static final class CapturingStatsDClient implements StatsDClient {
+    private final List<Gauge> gauges = new ArrayList<>();
+
+    @Override
+    public void incrementCounter(String metricName, String... tags) {}
+
+    @Override
+    public void count(String metricName, long delta, String... tags) {}
+
+    @Override
+    public void gauge(String metricName, long value, String... tags) {
+      gauges.add(new Gauge(metricName, value, tags));
+    }
+
+    @Override
+    public void gauge(String metricName, double value, String... tags) {}
+
+    @Override
+    public void histogram(String metricName, long value, String... tags) {}
+
+    @Override
+    public void histogram(String metricName, double value, String... tags) {}
+
+    @Override
+    public void distribution(String metricName, long value, String... tags) {}
+
+    @Override
+    public void distribution(String metricName, double value, String... tags) {}
+
+    @Override
+    public void serviceCheck(
+        String serviceCheckName, String status, String message, String... tags) {}
+
+    @Override
+    public void error(Exception error) {}
+
+    @Override
+    public int getErrorCount() {
+      return 0;
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/dd-java-agent/agent-jmxfetch/src/test/java/datadog/trace/agent/jmxfetch/JvmThreadCountCollectorTest.java
+++ b/dd-java-agent/agent-jmxfetch/src/test/java/datadog/trace/agent/jmxfetch/JvmThreadCountCollectorTest.java
@@ -1,0 +1,48 @@
+package datadog.trace.agent.jmxfetch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class JvmThreadCountCollectorTest {
+
+  @Test
+  void collectReportsPositiveBucketsForDaemonAndState() {
+    List<Bucket> buckets = new ArrayList<>();
+
+    JvmThreadCountCollector.collect(
+        (daemon, state, count) -> buckets.add(new Bucket(daemon, state, count)));
+
+    assertFalse(buckets.isEmpty(), "Expected at least one thread count bucket");
+
+    Set<Thread.State> expectedStates = EnumSet.allOf(Thread.State.class);
+    boolean sawDaemon = false;
+    boolean sawNonDaemon = false;
+    for (Bucket bucket : buckets) {
+      assertTrue(bucket.count > 0, "Buckets should skip zero counts");
+      assertTrue(expectedStates.contains(bucket.state), "Unexpected thread state: " + bucket.state);
+      sawDaemon |= bucket.daemon;
+      sawNonDaemon |= !bucket.daemon;
+    }
+
+    assertTrue(sawDaemon, "Expected at least one daemon bucket");
+    assertTrue(sawNonDaemon, "Expected at least one non-daemon bucket");
+  }
+
+  private static final class Bucket {
+    private final boolean daemon;
+    private final Thread.State state;
+    private final long count;
+
+    private Bucket(boolean daemon, Thread.State state, long count) {
+      this.daemon = daemon;
+      this.state = state;
+      this.count = count;
+    }
+  }
+}

--- a/dd-java-agent/agent-jmxfetch/src/test/java/datadog/trace/agent/jmxfetch/JvmThreadCountStatsDReporterTest.java
+++ b/dd-java-agent/agent-jmxfetch/src/test/java/datadog/trace/agent/jmxfetch/JvmThreadCountStatsDReporterTest.java
@@ -1,0 +1,100 @@
+package datadog.trace.agent.jmxfetch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.metrics.api.statsd.StatsDClient;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class JvmThreadCountStatsDReporterTest {
+
+  @Test
+  void reportOnceEmitsGaugeWithCommonAndThreadTags() {
+    CapturingStatsDClient statsd = new CapturingStatsDClient();
+    Map<String, String> commonTags = new LinkedHashMap<>();
+    commonTags.put("service", "test-service");
+    commonTags.put("env", "test");
+
+    new JvmThreadCountStatsDReporter(statsd, commonTags, 1_000L, () -> true).reportOnce();
+
+    assertFalse(statsd.gauges.isEmpty(), "Expected at least one gauge emission");
+    for (Gauge gauge : statsd.gauges) {
+      assertEquals(JvmThreadCountStatsDReporter.METRIC_NAME, gauge.metricName);
+      assertTrue(gauge.value > 0, "Buckets should skip zero counts");
+      assertContainsPrefix(gauge.tags, "service:test-service");
+      assertContainsPrefix(gauge.tags, "env:test");
+      assertContainsPrefix(gauge.tags, "jvm.thread.daemon:");
+      assertContainsPrefix(gauge.tags, "jvm.thread.state:");
+    }
+  }
+
+  private static void assertContainsPrefix(String[] tags, String expectedPrefix) {
+    for (String tag : tags) {
+      if (tag.startsWith(expectedPrefix)) {
+        return;
+      }
+    }
+    throw new AssertionError("Missing tag prefix " + expectedPrefix);
+  }
+
+  private static final class Gauge {
+    private final String metricName;
+    private final long value;
+    private final String[] tags;
+
+    private Gauge(String metricName, long value, String[] tags) {
+      this.metricName = metricName;
+      this.value = value;
+      this.tags = tags;
+    }
+  }
+
+  private static final class CapturingStatsDClient implements StatsDClient {
+    private final List<Gauge> gauges = new ArrayList<>();
+
+    @Override
+    public void incrementCounter(String metricName, String... tags) {}
+
+    @Override
+    public void count(String metricName, long delta, String... tags) {}
+
+    @Override
+    public void gauge(String metricName, long value, String... tags) {
+      gauges.add(new Gauge(metricName, value, tags));
+    }
+
+    @Override
+    public void gauge(String metricName, double value, String... tags) {}
+
+    @Override
+    public void histogram(String metricName, long value, String... tags) {}
+
+    @Override
+    public void histogram(String metricName, double value, String... tags) {}
+
+    @Override
+    public void distribution(String metricName, long value, String... tags) {}
+
+    @Override
+    public void distribution(String metricName, double value, String... tags) {}
+
+    @Override
+    public void serviceCheck(String serviceCheckName, String status, String message, String... tags) {}
+
+    @Override
+    public void error(Exception error) {}
+
+    @Override
+    public int getErrorCount() {
+      return 0;
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/dd-java-agent/agent-jmxfetch/src/test/java/datadog/trace/agent/jmxfetch/JvmThreadCountStatsDReporterTest.java
+++ b/dd-java-agent/agent-jmxfetch/src/test/java/datadog/trace/agent/jmxfetch/JvmThreadCountStatsDReporterTest.java
@@ -84,7 +84,8 @@ class JvmThreadCountStatsDReporterTest {
     public void distribution(String metricName, double value, String... tags) {}
 
     @Override
-    public void serviceCheck(String serviceCheckName, String status, String message, String... tags) {}
+    public void serviceCheck(
+        String serviceCheckName, String status, String message, String... tags) {}
 
     @Override
     public void error(Exception error) {}


### PR DESCRIPTION
## Summary
- add a StatsD runtime metrics reporter for `jvm.thread.count` when OTLP runtime metrics are not enabled
- add raw JVM GC MXBean metrics via StatsD so the reported values can match `GarbageCollectorMXBean` directly
- share the JVM thread state bucketing logic between the StatsD and OTLP paths to avoid divergent implementations
- add tests for thread bucket collection, raw GC MXBean collection, and StatsD tag emission

## Thread metric details
The thread metric is emitted as `jvm.thread.count` with these tags:
- `jvm.thread.daemon:true|false`
- `jvm.thread.state:<state>`

`jvm.thread.state` uses the lowercase `Thread.State` names:
- `new`
- `runnable`
- `blocked`
- `waiting`
- `timed_waiting`
- `terminated`

## Raw GC metric details
The raw GC metrics are emitted from `GarbageCollectorMXBean` values without mapping collectors into major/minor groups:
- `jvm.gc.collection_count`: raw `GarbageCollectorMXBean#getCollectionCount()` value
- `jvm.gc.collection_time`: raw `GarbageCollectorMXBean#getCollectionTime()` value, in JVM MXBean milliseconds

Both metrics include the original collector name as a DogStatsD tag:
- `gc:<collector name>`

This keeps values aligned with Java MXBean readings and preserves collector identity, similar to the Prometheus JVM collector model.

## Verification
- `./gradlew :dd-java-agent:agent-jmxfetch:test --tests datadog.trace.agent.jmxfetch.JvmGcStatsDReporterTest --tests datadog.trace.agent.jmxfetch.JvmThreadCountCollectorTest --tests datadog.trace.agent.jmxfetch.JvmThreadCountStatsDReporterTest`
- `./gradlew :dd-java-agent:agent-jmxfetch:spotlessCheck`