### PR TITLE
fix: avoid JDK 7 trace queue spin loop in guance-105

### DIFF
--- a/.github/scripts/repack-jdk7-agent.sh
+++ b/.github/scripts/repack-jdk7-agent.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <base-agent.jar> <queue-fix.jar> <output-agent.jar>" >&2
+  exit 2
+fi
+
+base_agent=$(realpath "$1")
+queue_fix=$(realpath "$2")
+output_agent=$(realpath -m "$3")
+
+if [[ ! -f "$base_agent" || ! -f "$queue_fix" ]]; then
+  echo "base agent or queue-fix JAR does not exist" >&2
+  exit 2
+fi
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+classes_dir="$work_dir/classes"
+payload_dir="$work_dir/payload"
+mkdir -p "$classes_dir" "$payload_dir"
+
+unzip -q "$queue_fix" -d "$classes_dir"
+
+class_count=0
+while IFS= read -r -d '' class_file; do
+  relative_path=${class_file#"$classes_dir/"}
+  classdata_path="$payload_dir/inst/${relative_path%.class}.classdata"
+  mkdir -p "$(dirname "$classdata_path")"
+  cp "$class_file" "$classdata_path"
+  class_count=$((class_count + 1))
+done < <(
+  find "$classes_dir/datadog/trace/agent" -type f \
+    \( -name 'PendingTraceBuffer*.class' -o -name 'TraceProcessingWorker*.class' \) \
+    -print0
+)
+
+if [[ $class_count -ne 9 ]]; then
+  echo "expected 9 patched classes, found $class_count" >&2
+  exit 1
+fi
+
+while IFS= read -r -d '' classdata_file; do
+  read -r major_high major_low < <(od -An -t u1 -j 6 -N 2 "$classdata_file")
+  class_major=$((major_high * 256 + major_low))
+  if [[ $class_major -ne 51 ]]; then
+    echo "$(basename "$classdata_file") has class major $class_major, expected 51" >&2
+    exit 1
+  fi
+  if strings "$classdata_file" | grep -Fq 'org/slf4j/'; then
+    echo "$(basename "$classdata_file") contains an unrelocated SLF4J reference" >&2
+    exit 1
+  fi
+done < <(find "$payload_dir" -type f -name '*.classdata' -print0)
+
+mkdir -p "$(dirname "$output_agent")"
+cp "$base_agent" "$output_agent"
+
+zip -q -d "$output_agent" \
+  'inst/datadog/trace/agent/core/PendingTraceBuffer*.classdata' \
+  'inst/datadog/trace/agent/common/writer/TraceProcessingWorker*.classdata'
+
+(
+  cd "$payload_dir"
+  zip -q -r "$output_agent" inst
+)
+
+pending_entry='inst/datadog/trace/agent/core/PendingTraceBuffer$DelayingPendingTraceBuffer.classdata'
+processor_entry='inst/datadog/trace/agent/common/writer/TraceProcessingWorker.classdata'
+
+for entry in "$pending_entry" "$processor_entry"; do
+  if ! unzip -Z1 "$output_agent" | grep -Fxq "$entry"; then
+    echo "missing patched entry: $entry" >&2
+    exit 1
+  fi
+  if ! unzip -p "$output_agent" "$entry" | strings | grep -Fq 'java/util/concurrent/ArrayBlockingQueue'; then
+    echo "patched entry does not reference ArrayBlockingQueue: $entry" >&2
+    exit 1
+  fi
+  if unzip -p "$output_agent" "$entry" | strings | grep -Fq 'MpscBlockingConsumerArrayQueue'; then
+    echo "patched entry still references MpscBlockingConsumerArrayQueue: $entry" >&2
+    exit 1
+  fi
+done
+
+sha256sum "$output_agent" > "$output_agent.sha256"
+echo "created $output_agent"
+cat "$output_agent.sha256"

--- a/.github/workflows/build-jdk7-queue-fix.yml
+++ b/.github/workflows/build-jdk7-queue-fix.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - fix/jdk7-queue-spin-v0.105.0
+      - maintenance/guance-105
 
 permissions:
   contents: read

--- a/.github/workflows/build-jdk7-queue-fix.yml
+++ b/.github/workflows/build-jdk7-queue-fix.yml
@@ -2,6 +2,9 @@ name: Build JDK 7 queue-fix agent
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - maintenance/guance-105
   push:
     branches:
       - fix/jdk7-queue-spin-v0.105.0

--- a/.github/workflows/build-jdk7-queue-fix.yml
+++ b/.github/workflows/build-jdk7-queue-fix.yml
@@ -1,0 +1,92 @@
+name: Build JDK 7 queue-fix agent
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - fix/jdk7-queue-spin-v0.105.0
+
+permissions:
+  contents: read
+
+env:
+  BASE_AGENT_URL: https://github.com/GuanceCloud/dd-trace-java/releases/download/guance-105/dd-java-agent-guance-0.105.0.jar
+  BASE_AGENT_SHA256: 4822115ec65d30a18894ab032cbd079403ee4ab852530906b23e38efab0a24b8
+  JDK7_URL: https://cdn.azul.com/zulu/bin/zulu7.56.0.11-ca-jdk7.0.352-linux_x64.tar.gz
+  JDK7_SHA256: 8a7387c1ed151474301b6553c6046f865dc6c1e1890bcf106acc2780c55727c8
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up build JDK
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: zulu
+          java-version: '11'
+          cache: gradle
+
+      - name: Download archived Guance 0.105.0 agent
+        shell: bash
+        run: |
+          mkdir -p build/jdk7-fix
+          curl --fail --location --retry 3 \
+            "$BASE_AGENT_URL" \
+            --output build/jdk7-fix/dd-java-agent-guance-0.105.0.jar
+          echo "$BASE_AGENT_SHA256  build/jdk7-fix/dd-java-agent-guance-0.105.0.jar" | sha256sum --check --strict
+
+      - name: Compile and test queue fix
+        shell: bash
+        run: |
+          ./gradlew --configure-on-demand --no-daemon \
+            :dd-trace-core:test \
+            --tests datadog.trace.core.PendingTraceBufferTest \
+            --tests datadog.trace.common.writer.TraceProcessingWorkerTest
+          ./gradlew --configure-on-demand --no-daemon \
+            :dd-trace-core:jdk7QueueFixJar
+
+      - name: Repack agent
+        shell: bash
+        run: |
+          chmod +x .github/scripts/repack-jdk7-agent.sh
+          .github/scripts/repack-jdk7-agent.sh \
+            build/jdk7-fix/dd-java-agent-guance-0.105.0.jar \
+            dd-trace-core/build/libs/*-jdk7-queue-fix.jar \
+            build/jdk7-fix/dd-java-agent-guance-0.105.0-jdk7-queue-fix.jar
+
+      - name: Download Java 7 runtime
+        shell: bash
+        run: |
+          curl --fail --location --retry 3 \
+            "$JDK7_URL" \
+            --output "$RUNNER_TEMP/zulu7.tar.gz"
+          echo "$JDK7_SHA256  $RUNNER_TEMP/zulu7.tar.gz" | sha256sum --check --strict
+
+      - name: Set up Java 7 runtime
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: jdkfile
+          jdk-file: ${{ runner.temp }}/zulu7.tar.gz
+          java-version: '7.0.352'
+          architecture: x64
+
+      - name: Smoke-test on Java 7
+        shell: bash
+        run: |
+          java -version
+          java -javaagent:build/jdk7-fix/dd-java-agent-guance-0.105.0-jdk7-queue-fix.jar -version
+
+      - name: Upload fixed agent
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dd-java-agent-guance-0.105.0-jdk7-queue-fix
+          path: |
+            build/jdk7-fix/dd-java-agent-guance-0.105.0-jdk7-queue-fix.jar
+            build/jdk7-fix/dd-java-agent-guance-0.105.0-jdk7-queue-fix.jar.sha256
+          if-no-files-found: error
+          retention-days: 30

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -1,4 +1,5 @@
 plugins {
+  id 'com.github.johnrengelman.shadow'
   id 'me.champeau.jmh'
 }
 
@@ -74,4 +75,20 @@ dependencies {
 jmh {
   jmhVersion = '1.28'
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+// Builds only the Java 7 queue-fix classes. The resulting classes are relocated in the same way
+// as the full agent's `inst` payload, so they can be injected into the archived guance-105 JAR
+// without resolving the historical AppSec and instrumentation dependencies.
+tasks.register('jdk7QueueFixJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+  archiveClassifier = 'jdk7-queue-fix'
+  configurations = []
+  from sourceSets.main.output
+
+  include 'datadog/trace/core/PendingTraceBuffer*.class'
+  include 'datadog/trace/common/writer/TraceProcessingWorker*.class'
+
+  relocate 'datadog.trace.common', 'datadog.trace.agent.common'
+  relocate 'datadog.trace.core', 'datadog.trace.agent.core'
+  relocate 'org.slf4j', 'datadog.slf4j'
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
@@ -13,10 +13,9 @@ import datadog.trace.core.CoreSpan;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.monitor.HealthMetrics;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.jctools.queues.MessagePassingQueue;
-import org.jctools.queues.MpscBlockingConsumerArrayQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,8 +31,8 @@ public class TraceProcessingWorker implements AutoCloseable {
   private static final Logger log = LoggerFactory.getLogger(TraceProcessingWorker.class);
 
   private final PrioritizationStrategy prioritizationStrategy;
-  private final MpscBlockingConsumerArrayQueue<Object> primaryQueue;
-  private final MpscBlockingConsumerArrayQueue<Object> secondaryQueue;
+  private final ArrayBlockingQueue<Object> primaryQueue;
+  private final ArrayBlockingQueue<Object> secondaryQueue;
   private final TraceSerializingHandler serializingHandler;
   private final Thread serializerThread;
   private final int capacity;
@@ -99,15 +98,14 @@ public class TraceProcessingWorker implements AutoCloseable {
     return primaryQueue.remainingCapacity();
   }
 
-  private static MpscBlockingConsumerArrayQueue<Object> createQueue(int capacity) {
-    return new MpscBlockingConsumerArrayQueue<>(capacity);
+  private static ArrayBlockingQueue<Object> createQueue(int capacity) {
+    return new ArrayBlockingQueue<>(capacity);
   }
 
-  public static class TraceSerializingHandler
-      implements Runnable, MessagePassingQueue.Consumer<Object> {
+  public static class TraceSerializingHandler implements Runnable {
 
-    private final MpscBlockingConsumerArrayQueue<Object> primaryQueue;
-    private final MpscBlockingConsumerArrayQueue<Object> secondaryQueue;
+    private final ArrayBlockingQueue<Object> primaryQueue;
+    private final ArrayBlockingQueue<Object> secondaryQueue;
     private final HealthMetrics healthMetrics;
     private final long ticksRequiredToFlush;
     private final boolean doTimeFlush;
@@ -115,8 +113,8 @@ public class TraceProcessingWorker implements AutoCloseable {
     private long lastTicks;
 
     public TraceSerializingHandler(
-        final MpscBlockingConsumerArrayQueue<Object> primaryQueue,
-        final MpscBlockingConsumerArrayQueue<Object> secondaryQueue,
+        final ArrayBlockingQueue<Object> primaryQueue,
+        final ArrayBlockingQueue<Object> secondaryQueue,
         final HealthMetrics healthMetrics,
         final PayloadDispatcher payloadDispatcher,
         final long flushInterval,
@@ -214,13 +212,15 @@ public class TraceProcessingWorker implements AutoCloseable {
       return false;
     }
 
-    private void consumeBatch(MessagePassingQueue<Object> queue) {
-      queue.drain(this, queue.size());
-    }
-
-    @Override
-    public void accept(Object event) {
-      onEvent(event);
+    private void consumeBatch(ArrayBlockingQueue<Object> queue) {
+      int size = queue.size();
+      for (int i = 0; i < size; i++) {
+        Object event = queue.poll();
+        if (event == null) {
+          break;
+        }
+        onEvent(event);
+      }
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
@@ -5,10 +5,9 @@ import static datadog.trace.util.AgentThreadFactory.THREAD_JOIN_TIMOUT_MS;
 import static datadog.trace.util.AgentThreadFactory.newAgentThread;
 
 import datadog.trace.api.time.TimeSource;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.jctools.queues.MessagePassingQueue;
-import org.jctools.queues.MpscBlockingConsumerArrayQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +38,7 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
     private static final long SEND_DELAY_NS = TimeUnit.MILLISECONDS.toNanos(500);
     private static final long SLEEP_TIME_MS = 100;
 
-    private final MpscBlockingConsumerArrayQueue<Element> queue;
+    private final ArrayBlockingQueue<Element> queue;
     private final Thread worker;
     private final TimeSource timeSource;
 
@@ -104,11 +103,13 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
       }
     }
 
-    private static final class WriteDrain implements MessagePassingQueue.Consumer<Element> {
-      private static final WriteDrain WRITE_DRAIN = new WriteDrain();
-
-      @Override
-      public void accept(Element pendingTrace) {
+    private void drainAndWrite() {
+      int size = queue.size();
+      for (int i = 0; i < size; i++) {
+        Element pendingTrace = queue.poll();
+        if (pendingTrace == null) {
+          break;
+        }
         pendingTrace.write();
       }
     }
@@ -150,8 +151,8 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
             Element pendingTrace = queue.take(); // block until available.
 
             if (pendingTrace instanceof FlushElement) {
-              // Since this is an MPSC queue, the drain needs to be called on the consumer thread
-              queue.drain(WriteDrain.WRITE_DRAIN);
+              // Drain a bounded snapshot on the consumer thread.
+              drainAndWrite();
               flushCounter.incrementAndGet();
               continue;
             }
@@ -184,7 +185,7 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
     }
 
     public DelayingPendingTraceBuffer(int bufferSize, TimeSource timeSource) {
-      this.queue = new MpscBlockingConsumerArrayQueue<>(bufferSize);
+      this.queue = new ArrayBlockingQueue<>(bufferSize);
       this.worker = newAgentThread(TRACE_MONITOR, new Worker());
       this.timeSource = timeSource;
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -163,13 +163,13 @@ class PendingTraceBufferTest extends DDSpecification {
     // Don't start the buffer thread
 
     when: "Fill the buffer"
-    for (i in  1..buffer.queue.capacity()) {
+    for (i in  1..BUFFER_SIZE) {
       addContinuation(newSpanOf(factory.create(DDId.ONE))).finish()
     }
 
     then:
     buffer.queue.size() == BUFFER_SIZE
-    buffer.queue.capacity() * bufferSpy.enqueue(_)
+    BUFFER_SIZE * bufferSpy.enqueue(_)
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * tracer.mapServiceName(_)
     _ * tracer.onStart(_)
@@ -366,14 +366,14 @@ class PendingTraceBufferTest extends DDSpecification {
     0 * _
 
     when: "fail to fill the buffer"
-    for (i in  1..buffer.queue.capacity()) {
+    for (i in  1..BUFFER_SIZE) {
       addContinuation(newSpanOf(span)).finish()
     }
 
     then:
     pendingTrace.isEnqueued == 1
     buffer.queue.size() == 1
-    buffer.queue.capacity() * bufferSpy.enqueue(_)
+    BUFFER_SIZE * bufferSpy.enqueue(_)
     _ * tracer.getPartialFlushMinSpans() >> 10000
     _ * tracer.mapServiceName(_)
     _ * tracer.onStart(_)


### PR DESCRIPTION
## 问题

在 JDK 7 上，guance-105 使用的 JCTools MpscBlockingConsumerArrayQueue 可能进入永久自旋，表现为 dd-trace-monitor 和 dd-trace-processor 长时间占满 CPU，堆栈停留在 spinWaitForElement / parkUntilNext。

## 修复

- 将两个 Agent 内部有界 MPSC 队列替换为 JDK 7 自带的 ArrayBlockingQueue
- 保持原容量、非阻塞入队和批量消费语义
- 增加只编译修复类的 ShadowJar 任务，沿用 Agent 的包重定位规则
- 增加重打包脚本：基于官方 guance-105 Release JAR 替换 9 个 classdata 文件
- 增加 GitHub Actions：校验基础 JAR 哈希、运行测试、重打包，并在 Zulu JDK 7u352 上做 javaagent 冒烟测试

## 验证

- PendingTraceBufferTest：9 个测试通过
- TraceProcessingWorkerTest：29 个测试通过
- 修复类 class major：51（Java 7）
- Zulu OpenJDK 7u352：java -javaagent:<fixed.jar> -version 正常退出

工作流产物名：dd-java-agent-guance-0.105.0-jdk7-queue-fix