### PR TITLE
Add opt-in CXF invoker fallback tracing

### DIFF
--- a/dd-java-agent/instrumentation/cxf-2.1/src/latestDepTest/java/cxf/CxfInvokerFallbackInstrumentationLatestTest.java
+++ b/dd-java-agent/instrumentation/cxf-2.1/src/latestDepTest/java/cxf/CxfInvokerFallbackInstrumentationLatestTest.java
@@ -1,0 +1,78 @@
+package cxf;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.core.DDSpan;
+import datadog.trace.junit.utils.config.WithConfig;
+import java.util.List;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.ExchangeImpl;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.service.invoker.Invoker;
+import org.junit.jupiter.api.Test;
+
+@WithConfig(key = "trace.cxf-invoker-fallback.enabled", value = "true")
+@WithConfig(
+    key = "trace.cxf-invoker-fallback.target-classes",
+    value = "cxf.CxfInvokerFallbackInstrumentationLatestTest$TestInvoker")
+class CxfInvokerFallbackInstrumentationLatestTest extends AbstractInstrumentationTest {
+
+  @Test
+  void createsServerSpanWhenNoServerContextExists() throws Exception {
+    assertNull(activeSpan());
+    assertEquals("ok", new TestInvoker().invoke(newHttpExchange(), null));
+    assertNull(activeSpan());
+
+    writer.waitForTraces(1);
+    List<DDSpan> trace = writer.firstTrace();
+    assertEquals(1, trace.size());
+    assertEquals("cxf.request", trace.get(0).getOperationName().toString());
+    assertEquals(201, trace.get(0).getHttpStatusCode());
+  }
+
+  @Test
+  void doesNotCreateAnotherSpanWhenOneIsAlreadyActive() throws Exception {
+    AgentSpan parent = startSpan("test", "existing.request");
+    try (AgentScope ignored = activateSpan(parent)) {
+      assertEquals("ok", new TestInvoker().invoke(newHttpExchange(), null));
+      assertSame(parent, activeSpan());
+    } finally {
+      parent.finish();
+    }
+
+    writer.waitForTraces(1);
+    List<DDSpan> trace = writer.firstTrace();
+    assertEquals(1, trace.size());
+    assertEquals("existing.request", trace.get(0).getOperationName().toString());
+  }
+
+  private static Exchange newHttpExchange() {
+    Exchange exchange = new ExchangeImpl();
+    Message request = new MessageImpl();
+    request.put(Message.HTTP_REQUEST_METHOD, "POST");
+    request.put("org.apache.cxf.request.url", "http://localhost/one/trigger");
+    exchange.setInMessage(request);
+    return exchange;
+  }
+
+  public static final class TestInvoker implements Invoker {
+    @Override
+    public Object invoke(Exchange exchange, Object request) {
+      assertNotNull(activeSpan());
+      Message response = new MessageImpl();
+      response.put(Message.RESPONSE_CODE, 201);
+      exchange.setOutMessage(response);
+      return "ok";
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/cxf-2.1/src/main/java/datadog/trace/instrumentation/cxf/CxfInvokerFallbackInstrumentation.java
+++ b/dd-java-agent/instrumentation/cxf-2.1/src/main/java/datadog/trace/instrumentation/cxf/CxfInvokerFallbackInstrumentation.java
@@ -1,0 +1,170 @@
+package datadog.trace.instrumentation.cxf;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.Java8BytecodeBridge.spanFromContext;
+import static datadog.trace.instrumentation.cxf.CxfInvokerServerDecorator.DECORATE;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import java.util.Collection;
+import java.util.List;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.Message;
+
+/**
+ * Creates an opt-in HTTP server span when CXF invokes a service without an active server context.
+ *
+ * <p>The regular CXF instrumentation only restores a context previously created by a servlet or
+ * another HTTP server integration. This fallback covers CXF deployments with a custom transport
+ * where no such context exists.
+ */
+@AutoService(InstrumenterModule.class)
+public final class CxfInvokerFallbackInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForConfiguredTypes, Instrumenter.HasMethodAdvice {
+
+  private final List<String> targetClasses;
+
+  public CxfInvokerFallbackInstrumentation() {
+    super("cxf-invoker-fallback");
+    targetClasses = InstrumenterConfig.get().getCxfInvokerFallbackTargetClasses();
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return false;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    // Fail closed: enabling the integration without an explicit target-class allowlist must never
+    // broaden instrumentation to every CXF Invoker implementation in the JVM.
+    return super.isEnabled() && !targetClasses.isEmpty();
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassNamed("org.apache.cxf.service.invoker.Invoker");
+  }
+
+  @Override
+  public Collection<String> configuredMatchingTypes() {
+    return targetClasses;
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".ServletHelper",
+      packageName + ".CxfMessageHeadersVisitor",
+      packageName + ".CxfInvokerServerDecorator",
+      packageName + ".CxfInvokerFallbackState",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod()
+            .and(named("invoke"))
+            .and(takesArguments(2))
+            .and(takesArgument(0, named("org.apache.cxf.message.Exchange"))),
+        getClass().getName() + "$FallbackAdvice");
+  }
+
+  public static final class FallbackAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static CxfInvokerFallbackState onEnter(@Advice.Argument(0) final Exchange exchange) {
+      if (exchange == null || AgentTracer.activeSpan() != null) {
+        return null;
+      }
+
+      final Message request = exchange.getInMessage();
+      if (request == null) {
+        return null;
+      }
+
+      // Preserve the existing CXF behavior first. This also makes the fallback independent of the
+      // order in which the built-in and opt-in advices are applied.
+      final Object servletContext =
+          ServletHelper.getServletRequestAttribute(
+              request.get("HTTP.REQUEST"), HttpServerDecorator.DD_CONTEXT_ATTRIBUTE);
+      if (servletContext instanceof Context) {
+        return new CxfInvokerFallbackState(((Context) servletContext).attach(), null);
+      }
+
+      if (!DECORATE.isInboundHttpRequest(request)) {
+        return null;
+      }
+
+      ContextScope scope = null;
+      AgentSpan span = null;
+      try {
+        final Context parentContext = DECORATE.extract(request);
+        final Context context = DECORATE.startSpan(request, parentContext);
+        span = spanFromContext(context);
+        scope = context.attach();
+        DECORATE.afterStart(span);
+        DECORATE.onRequest(span, null, request, parentContext);
+        return new CxfInvokerFallbackState(scope, span);
+      } catch (final Throwable ignored) {
+        try {
+          if (scope != null) {
+            scope.close();
+          }
+        } finally {
+          if (span != null) {
+            span.finish();
+          }
+        }
+        return null;
+      }
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void onExit(
+        @Advice.Argument(0) final Exchange exchange,
+        @Advice.Enter final CxfInvokerFallbackState state,
+        @Advice.Thrown final Throwable throwable) {
+      if (state == null) {
+        return;
+      }
+
+      final AgentSpan span = state.getCreatedSpan();
+      try {
+        if (span != null) {
+          Message response = null;
+          if (exchange != null) {
+            response = exchange.getOutMessage();
+            if (response == null) {
+              response = exchange.getOutFaultMessage();
+            }
+          }
+          DECORATE.onResponse(span, response);
+          DECORATE.onError(span, throwable);
+          DECORATE.beforeFinish(span);
+        }
+      } finally {
+        try {
+          state.getScope().close();
+        } finally {
+          if (span != null) {
+            span.finish();
+          }
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/cxf-2.1/src/main/java/datadog/trace/instrumentation/cxf/CxfInvokerFallbackState.java
+++ b/dd-java-agent/instrumentation/cxf-2.1/src/main/java/datadog/trace/instrumentation/cxf/CxfInvokerFallbackState.java
@@ -1,0 +1,22 @@
+package datadog.trace.instrumentation.cxf;
+
+import datadog.context.ContextScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+public final class CxfInvokerFallbackState {
+  private final ContextScope scope;
+  private final AgentSpan createdSpan;
+
+  public CxfInvokerFallbackState(ContextScope scope, AgentSpan createdSpan) {
+    this.scope = scope;
+    this.createdSpan = createdSpan;
+  }
+
+  public ContextScope getScope() {
+    return scope;
+  }
+
+  public AgentSpan getCreatedSpan() {
+    return createdSpan;
+  }
+}

--- a/dd-java-agent/instrumentation/cxf-2.1/src/main/java/datadog/trace/instrumentation/cxf/CxfInvokerServerDecorator.java
+++ b/dd-java-agent/instrumentation/cxf-2.1/src/main/java/datadog/trace/instrumentation/cxf/CxfInvokerServerDecorator.java
@@ -1,0 +1,117 @@
+package datadog.trace.instrumentation.cxf;
+
+import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase;
+import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import org.apache.cxf.message.Message;
+
+public final class CxfInvokerServerDecorator
+    extends HttpServerDecorator<Message, Object, Message, Message> {
+  public static final CxfInvokerServerDecorator DECORATE = new CxfInvokerServerDecorator();
+
+  private static final CharSequence COMPONENT = UTF8BytesString.create("cxf-invoker-fallback");
+  private static final CharSequence OPERATION_NAME = UTF8BytesString.create("cxf.request");
+  // These keys are used by CXF 2.x, but constants were only added to Message in later releases.
+  private static final String REQUEST_URI = "org.apache.cxf.request.uri";
+  private static final String REQUEST_URL = "org.apache.cxf.request.url";
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {"cxf-invoker-fallback"};
+  }
+
+  @Override
+  protected CharSequence component() {
+    return COMPONENT;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Message> getter() {
+    return CxfMessageHeadersVisitor.INSTANCE;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Message> responseGetter() {
+    return CxfMessageHeadersVisitor.INSTANCE;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return OPERATION_NAME;
+  }
+
+  @Override
+  protected String method(Message request) {
+    final Object method = request.get(Message.HTTP_REQUEST_METHOD);
+    return method == null ? null : method.toString();
+  }
+
+  @Override
+  protected URIDataAdapter url(Message request) {
+    String url = stringValue(request.get(REQUEST_URL));
+    if (url == null) {
+      url = stringValue(request.get(REQUEST_URI));
+    }
+    if (url == null) {
+      url = stringValue(request.get(Message.PATH_INFO));
+    }
+    if (url == null) {
+      return null;
+    }
+
+    final String query = stringValue(request.get(Message.QUERY_STRING));
+    if (query != null && url.indexOf('?') < 0) {
+      url = url + '?' + query;
+    }
+    return URIDataAdapterBase.fromURI(url, URIDefaultDataAdapter::new);
+  }
+
+  @Override
+  protected String peerHostIP(Object connection) {
+    return null;
+  }
+
+  @Override
+  protected int peerPort(Object connection) {
+    return UNSET_PORT;
+  }
+
+  @Override
+  protected int status(Message response) {
+    if (response == null) {
+      return UNSET_STATUS;
+    }
+    final Object status = response.get(Message.RESPONSE_CODE);
+    if (status instanceof Number) {
+      return ((Number) status).intValue();
+    }
+    if (status != null) {
+      try {
+        return Integer.parseInt(status.toString());
+      } catch (NumberFormatException ignored) {
+        // leave the response status unset
+      }
+    }
+    return UNSET_STATUS;
+  }
+
+  public boolean isInboundHttpRequest(Message request) {
+    final Object method = request.get(Message.HTTP_REQUEST_METHOD);
+    return method != null
+        && !method.toString().isEmpty()
+        && !Boolean.TRUE.equals(request.get(Message.REQUESTOR_ROLE));
+  }
+
+  private static String stringValue(Object value) {
+    if (value == null) {
+      return null;
+    }
+    final String string = value.toString();
+    return string.isEmpty() ? null : string;
+  }
+}

--- a/dd-java-agent/instrumentation/cxf-2.1/src/main/java/datadog/trace/instrumentation/cxf/CxfMessageHeadersVisitor.java
+++ b/dd-java-agent/instrumentation/cxf-2.1/src/main/java/datadog/trace/instrumentation/cxf/CxfMessageHeadersVisitor.java
@@ -1,0 +1,45 @@
+package datadog.trace.instrumentation.cxf;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import java.lang.reflect.Array;
+import java.util.Map;
+import org.apache.cxf.message.Message;
+
+public final class CxfMessageHeadersVisitor implements AgentPropagation.ContextVisitor<Message> {
+  public static final CxfMessageHeadersVisitor INSTANCE = new CxfMessageHeadersVisitor();
+
+  private CxfMessageHeadersVisitor() {}
+
+  @Override
+  public void forEachKey(Message carrier, AgentPropagation.KeyClassifier classifier) {
+    final Object protocolHeaders = carrier.get(Message.PROTOCOL_HEADERS);
+    if (!(protocolHeaders instanceof Map)) {
+      return;
+    }
+
+    for (Map.Entry<?, ?> entry : ((Map<?, ?>) protocolHeaders).entrySet()) {
+      if (entry.getKey() == null || entry.getValue() == null) {
+        continue;
+      }
+      final String key = entry.getKey().toString();
+      final Object value = entry.getValue();
+      if (value instanceof Iterable) {
+        for (Object item : (Iterable<?>) value) {
+          if (item != null && !classifier.accept(key, item.toString())) {
+            return;
+          }
+        }
+      } else if (value.getClass().isArray()) {
+        final int length = Array.getLength(value);
+        for (int i = 0; i < length; i++) {
+          final Object item = Array.get(value, i);
+          if (item != null && !classifier.accept(key, item.toString())) {
+            return;
+          }
+        }
+      } else if (!classifier.accept(key, value.toString())) {
+        return;
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/cxf-2.1/src/test/java/cxf/CxfInvokerFallbackInstrumentationTest.java
+++ b/dd-java-agent/instrumentation/cxf-2.1/src/test/java/cxf/CxfInvokerFallbackInstrumentationTest.java
@@ -1,0 +1,108 @@
+package cxf;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.api.DDTraceId;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.core.DDSpan;
+import datadog.trace.junit.utils.config.WithConfig;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.ExchangeImpl;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.service.invoker.Invoker;
+import org.junit.jupiter.api.Test;
+
+@WithConfig(key = "trace.cxf-invoker-fallback.enabled", value = "true")
+@WithConfig(
+    key = "trace.cxf-invoker-fallback.target-classes",
+    value = "cxf.CxfInvokerFallbackInstrumentationTest$TestInvoker")
+class CxfInvokerFallbackInstrumentationTest extends AbstractInstrumentationTest {
+
+  @Test
+  void createsServerSpanWhenNoServerContextExists() throws Exception {
+    Exchange exchange = newHttpExchange();
+
+    assertNull(activeSpan());
+    assertEquals("ok", new TestInvoker().invoke(exchange, null));
+    assertNull(activeSpan());
+
+    writer.waitForTraces(1);
+    List<DDSpan> trace = writer.firstTrace();
+    assertEquals(1, trace.size());
+    DDSpan span = trace.get(0);
+    assertEquals("cxf.request", span.getOperationName().toString());
+    assertEquals("cxf-invoker-fallback", span.getTag("component").toString());
+    assertEquals("server", span.getTag("span.kind"));
+    assertEquals("POST", span.getTag("http.method"));
+    assertEquals(201, span.getHttpStatusCode());
+  }
+
+  @Test
+  void continuesIncomingDistributedTrace() throws Exception {
+    Exchange exchange = newHttpExchange();
+    Map<String, List<String>> headers = new LinkedHashMap<>();
+    headers.put("x-datadog-trace-id", Collections.singletonList("123"));
+    headers.put("x-datadog-parent-id", Collections.singletonList("456"));
+    headers.put("x-datadog-sampling-priority", Collections.singletonList("1"));
+    exchange.getInMessage().put(Message.PROTOCOL_HEADERS, headers);
+
+    assertEquals("ok", new TestInvoker().invoke(exchange, null));
+
+    writer.waitForTraces(1);
+    DDSpan span = writer.firstTrace().get(0);
+    assertEquals(DDTraceId.from(123), span.getTraceId());
+    assertEquals(456, span.getParentId());
+  }
+
+  @Test
+  void doesNotCreateAnotherSpanWhenOneIsAlreadyActive() throws Exception {
+    AgentSpan parent = startSpan("test", "existing.request");
+    try (AgentScope ignored = activateSpan(parent)) {
+      assertEquals("ok", new TestInvoker().invoke(newHttpExchange(), null));
+      assertSame(parent, activeSpan());
+    } finally {
+      parent.finish();
+    }
+
+    writer.waitForTraces(1);
+    List<DDSpan> trace = writer.firstTrace();
+    assertEquals(1, trace.size());
+    assertEquals("existing.request", trace.get(0).getOperationName().toString());
+  }
+
+  private static Exchange newHttpExchange() {
+    Exchange exchange = new ExchangeImpl();
+    Message request = new MessageImpl();
+    request.put(Message.HTTP_REQUEST_METHOD, "POST");
+    request.put("org.apache.cxf.request.url", "http://localhost/one/trigger");
+    Map<String, List<String>> headers =
+        Collections.singletonMap("user-agent", Collections.singletonList("test-client"));
+    request.put(Message.PROTOCOL_HEADERS, headers);
+    exchange.setInMessage(request);
+    return exchange;
+  }
+
+  public static final class TestInvoker implements Invoker {
+    @Override
+    public Object invoke(Exchange exchange, Object request) {
+      assertNotNull(activeSpan());
+      Message response = new MessageImpl();
+      response.put(Message.RESPONSE_CODE, 201);
+      exchange.setOutMessage(response);
+      return "ok";
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/cxf-2.1/src/test/java/datadog/trace/instrumentation/cxf/CxfInvokerServerDecoratorTest.java
+++ b/dd-java-agent/instrumentation/cxf-2.1/src/test/java/datadog/trace/instrumentation/cxf/CxfInvokerServerDecoratorTest.java
@@ -1,0 +1,90 @@
+package datadog.trace.instrumentation.cxf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.junit.utils.config.WithConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.jupiter.api.Test;
+
+class CxfInvokerServerDecoratorTest {
+
+  @Test
+  void fallbackInstrumentationIsDisabledByDefault() {
+    assertFalse(new CxfInvokerFallbackInstrumentation().defaultEnabled());
+  }
+
+  @Test
+  @WithConfig(key = "trace.cxf-invoker-fallback.enabled", value = "true")
+  void enablingWithoutTargetClassAllowlistFailsClosed() {
+    CxfInvokerFallbackInstrumentation instrumentation = new CxfInvokerFallbackInstrumentation();
+
+    assertFalse(instrumentation.isEnabled());
+  }
+
+  @Test
+  @WithConfig(key = "trace.cxf-invoker-fallback.enabled", value = "true")
+  @WithConfig(
+      key = "trace.cxf-invoker-fallback.target-classes",
+      value = "example.FirstInvoker,example.SecondInvoker")
+  void configuredTargetClassAllowlistIsExact() {
+    CxfInvokerFallbackInstrumentation instrumentation = new CxfInvokerFallbackInstrumentation();
+
+    assertTrue(instrumentation.isEnabled());
+    assertEquals(
+        Arrays.asList("example.FirstInvoker", "example.SecondInvoker"),
+        instrumentation.configuredMatchingTypes());
+  }
+
+  @Test
+  void identifiesOnlyInboundHttpRequests() {
+    Message request = new MessageImpl();
+
+    assertFalse(CxfInvokerServerDecorator.DECORATE.isInboundHttpRequest(request));
+
+    request.put(Message.HTTP_REQUEST_METHOD, "POST");
+    assertTrue(CxfInvokerServerDecorator.DECORATE.isInboundHttpRequest(request));
+
+    request.put(Message.REQUESTOR_ROLE, true);
+    assertFalse(CxfInvokerServerDecorator.DECORATE.isInboundHttpRequest(request));
+  }
+
+  @Test
+  void readsResponseStatusFromNumbersAndStrings() {
+    Message response = new MessageImpl();
+
+    response.put(Message.RESPONSE_CODE, 202);
+    assertEquals(202, CxfInvokerServerDecorator.DECORATE.status(response));
+
+    response.put(Message.RESPONSE_CODE, "503");
+    assertEquals(503, CxfInvokerServerDecorator.DECORATE.status(response));
+  }
+
+  @Test
+  void visitsEveryProtocolHeaderValue() {
+    Message request = new MessageImpl();
+    Map<String, Object> headers = new LinkedHashMap<>();
+    headers.put("traceparent", Arrays.asList("first", "second"));
+    headers.put("x-datadog-trace-id", new String[] {"123"});
+    request.put(Message.PROTOCOL_HEADERS, headers);
+
+    List<String> visited = new ArrayList<>();
+    CxfMessageHeadersVisitor.INSTANCE.forEachKey(
+        request,
+        (key, value) -> {
+          visited.add(key + '=' + value);
+          return true;
+        });
+
+    assertEquals(
+        Arrays.asList("traceparent=first", "traceparent=second", "x-datadog-trace-id=123"),
+        visited);
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -102,6 +102,8 @@ public final class TraceInstrumentationConfig {
       "trace.http.url.connection.class.name";
 
   public static final String AXIS_TRANSPORT_CLASS_NAME = "trace.axis.transport.class.name";
+  public static final String CXF_INVOKER_FALLBACK_TARGET_CLASSES =
+      "trace.cxf-invoker-fallback.target-classes";
 
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
       "trace.runtime.context.field.injection";

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -23,9 +23,9 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANNOTATIONS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANNOTATION_ASYNC;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_EXECUTORS_ALL;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_METHODS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_METHOD_FILE_LENGTH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_METHOD_PACKAGES;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_METHODS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_NATIVE_METHODS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_OTEL_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_USM_ENABLED;
@@ -58,6 +58,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.AKKA_FORK_JOIN
 import static datadog.trace.api.config.TraceInstrumentationConfig.AXIS_TRANSPORT_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.CODE_ORIGIN_FOR_SPANS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.CODE_ORIGIN_FOR_SPANS_INTERFACE_SUPPORT;
+import static datadog.trace.api.config.TraceInstrumentationConfig.CXF_INVOKER_FALLBACK_TARGET_CLASSES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.DETAILED_INSTRUMENTATION_ERRORS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.EXPERIMENTAL_DEFER_INTEGRATIONS_UNTIL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_URL_CONNECTION_CLASS_NAME;
@@ -186,6 +187,7 @@ public class InstrumenterConfig {
 
   private final String httpURLConnectionClassName;
   private final String axisTransportClassName;
+  private final List<String> cxfInvokerFallbackTargetClasses;
   private final boolean websocketTracingEnabled;
   private final boolean pekkoSchedulerEnabled;
 
@@ -326,6 +328,8 @@ public class InstrumenterConfig {
 
     httpURLConnectionClassName = configProvider.getString(HTTP_URL_CONNECTION_CLASS_NAME, "");
     axisTransportClassName = configProvider.getString(AXIS_TRANSPORT_CLASS_NAME, "");
+    cxfInvokerFallbackTargetClasses =
+        tryMakeImmutableList(configProvider.getList(CXF_INVOKER_FALLBACK_TARGET_CLASSES));
 
     akkaForkJoinTaskName = configProvider.getString(AKKA_FORK_JOIN_TASK_NAME, "");
     akkaForkJoinExecutorTaskName = configProvider.getString(AKKA_FORK_JOIN_EXECUTOR_TASK_NAME, "");
@@ -618,6 +622,10 @@ public class InstrumenterConfig {
     return axisTransportClassName;
   }
 
+  public List<String> getCxfInvokerFallbackTargetClasses() {
+    return cxfInvokerFallbackTargetClasses;
+  }
+
   public String getAkkaForkJoinTaskName() {
     return akkaForkJoinTaskName;
   }
@@ -886,6 +894,8 @@ public class InstrumenterConfig {
         + ", axisTransportClassName='"
         + axisTransportClassName
         + '\''
+        + ", cxfInvokerFallbackTargetClasses="
+        + cxfInvokerFallbackTargetClasses
         + ", excludedClasses="
         + excludedClasses
         + ", excludedClassesFile="

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -5281,6 +5281,14 @@
         "aliases": ["DD_TRACE_INTEGRATION_CXF_ENABLED", "DD_INTEGRATION_CXF_ENABLED"]
       }
     ],
+    "DD_TRACE_CXF_INVOKER_FALLBACK_TARGET_CLASSES": [
+      {
+        "version": "A",
+        "type": "string",
+        "default": null,
+        "aliases": []
+      }
+    ],
     "DD_TRACE_CXF_INVOKER_ENABLED": [
       {
         "version": "A",


### PR DESCRIPTION
# What Does This Do

Adds an opt-in CXF invoker fallback instrumentation for custom transports that reach a CXF `Invoker` without an active HTTP server context.

- Targets only explicitly configured invoker implementation classes via `Instrumenter.ForConfiguredTypes`.
- Restores an existing servlet context before considering a fallback span.
- Extracts Datadog/W3C propagation headers from CXF protocol headers.
- Creates and decorates a `cxf.request` server span only for inbound HTTP requests with no active context.
- Records response status and errors, then closes the scope and span on method exit.
- Keeps the existing `InvokerInstrumentation` unchanged.

The integration is disabled by default and fails closed unless both the integration flag and an exact target-class allowlist are configured:

```text
-Ddd.trace.cxf-invoker-fallback.enabled=true
-Ddd.trace.cxf-invoker-fallback.target-classes=com.actionsoft.bpms.server.ws.RsProxyInvoker
```

# Motivation

Some custom CXF deployments bypass the servlet integration or lose its request context before invoking the service. In that case application logs have no trace ID and downstream work can appear as a separate trace. This fallback restores a recoverable servlet context first, otherwise extracts the incoming distributed context and creates a narrowly scoped server span.

Exact configured type matching limits the bytecode transformation to the selected invoker implementation instead of every CXF invoker visible to an application class loader.

# Additional Notes

The implementation remains intentionally conservative:

- Enabling the integration without `target-classes` has no effect.
- Requests with an active span do not create another span.
- Non-HTTP and CXF requestor-side messages are ignored.
- Multiple target classes can be configured as a comma-separated list.
- Configuration is read at JVM startup.

Validation completed:

- CXF base instrumentation tests, including incoming trace/parent header continuation
- CXF 3 latest dependency test
- Latest CXF dependency test
- Muzzle compatibility checks across supported CXF 2.x, 3.x, and 4.x versions
- Spotless Java checks
- Full `:dd-java-agent:shadowJar` build

# Contributor Checklist

- [x] Title follows the contribution guidelines.
- [x] Existing CODEOWNERS rules already cover the CXF instrumentation and metadata paths.
- [x] New configuration is registered in `TraceInstrumentationConfig`, `InstrumenterConfig`, and supported configuration metadata.
- [x] Tests cover default-disabled, fail-closed, exact target configuration, propagation, active-context, HTTP detection, response status, and header iteration behavior.
