### PR TITLE
修复 128 位 Trace ID 的 Datadog 传播格式

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/DD128bTraceId.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DD128bTraceId.java
@@ -170,12 +170,12 @@ public class DD128bTraceId extends DDTraceId {
 
   @Override
   public String toString() {
-    // String s = this.str;
+    String s = this.str;
     // This race condition is intentional and benign.
     // The worst that can happen is that an identical value is produced and written into the field.
-    // if (s == null) {
-    //   this.str = s = Long.toUnsignedString(this.lowOrderBits);
-    // }
-    return toHexString();
+    if (s == null) {
+      this.str = s = Long.toUnsignedString(this.lowOrderBits);
+    }
+    return s;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1679,7 +1679,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
           span.setEndpointTracker(tracker);
         }
       }
-      span.setTag("trace_128_bit_id", span.getTraceId().toString());
+      span.setTag("trace_128_bit_id", span.getTraceId().toHexString());
 
       if (!Objects.equals(DDTraceCoreInfo.VERSION, "")) {
         span.setTag("dd_ext_version", DDTraceCoreInfo.VERSION);

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/DatadogHttpInjectorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/DatadogHttpInjectorTest.java
@@ -148,7 +148,7 @@ class DatadogHttpInjectorTest extends AbstractHttpInjectorTest {
             : "_dd.p.dm=-4,_dd.p.tid="
                 + toHexStringPadded(traceId.toHighOrderLong(), 16)
                 + ",_dd.p.anytag=value";
-    assertEquals(traceId.toString(), carrier.get(TRACE_ID_KEY));
+    assertEquals(Long.toUnsignedString(traceId.toLong()), carrier.get(TRACE_ID_KEY));
     assertEquals("2", carrier.get(SPAN_ID_KEY));
     assertEquals(expectedT0, carrier.get(OT_BAGGAGE_PREFIX + "t0"));
     assertEquals("v1", carrier.get(OT_BAGGAGE_PREFIX + "k1"));


### PR DESCRIPTION
## 问题

观测云分支将 `DD128bTraceId.toString()` 改为返回完整 128 位十六进制值，导致 Datadog HTTP 注入器把该值写入 `x-datadog-trace-id`。该请求头按协议应为 Trace ID 低 64 位的无符号十进制，高 64 位由 `_dd.p.tid` 携带，因此下游 Nginx 无法把 Span 关联到 Java 调用链。

## 变更

- 恢复 `DD128bTraceId.toString()` 的低 64 位无符号十进制语义
- `trace_128_bit_id` 标签显式使用 `toHexString()`，继续保留完整 128 位十六进制值
- 强化 Datadog HTTP 注入测试，直接校验协议要求的低 64 位十进制，不再复用被测 `toString()`

## 验证

- `DDTraceIdTest`：81 个测试通过，0 失败
- `DatadogHttpInjectorTest`：11 个测试通过，0 失败
- `git diff --check` 通过
- `./gradlew spotlessCheck --no-daemon` 执行后被主分支已有的 `dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java` 格式差异阻断；该文件不属于本 PR，本 PR 修改的文件未报告格式问题

Fixes #161