### PR TITLE
Honor single-trace WebSocket configuration for outbound spans

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/WebsocketDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/WebsocketDecorator.java
@@ -151,8 +151,8 @@ public class WebsocketDecorator extends BaseDecorator {
       final AgentSpan handshakeSpan = handlerContext.getHandshakeSpan();
       boolean inheritSampling = config.isWebsocketMessagesInheritSampling();
       boolean useDedicatedTraces = config.isWebsocketMessagesSeparateTraces();
-      if (traceStarter) {
-        if (useDedicatedTraces) {
+      if (useDedicatedTraces) {
+        if (traceStarter) {
           wsSpan = startSpan(WEBSOCKET.toString(), operationName, null);
           if (inheritSampling) {
             wsSpan.copyPropagationAndBaggage(handshakeSpan);
@@ -161,10 +161,10 @@ public class WebsocketDecorator extends BaseDecorator {
             wsSpan.setTag(DECISION_MAKER_RESOURCE, handshakeSpan.getResourceName());
           }
         } else {
-          wsSpan = startSpan(WEBSOCKET.toString(), operationName, handshakeSpan.spanContext());
+          wsSpan = startSpan(WEBSOCKET.toString(), operationName);
         }
       } else {
-        wsSpan = startSpan(WEBSOCKET.toString(), operationName);
+        wsSpan = startSpan(WEBSOCKET.toString(), operationName, handshakeSpan.spanContext());
       }
       handlerContext.setWebsocketSpan(wsSpan);
       afterStart(wsSpan);
@@ -178,9 +178,8 @@ public class WebsocketDecorator extends BaseDecorator {
       if (config.isWebsocketTagSessionId()) {
         wsSpan.setTag(WEBSOCKET_SESSION_ID, handlerContext.getSessionId());
       }
-      if (useDedicatedTraces || !traceStarter) {
-        // the link is not added if the user wants to have receive frames on the same trace as the
-        // handshake
+      if (useDedicatedTraces) {
+        // The link is not added if the user wants all frames on the same trace as the handshake.
         wsSpan.addLink(
             SpanLink.from(
                 inheritSampling

--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -2462,6 +2462,8 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       }
       if (traceStarter && Config.get().isWebsocketMessagesSeparateTraces()) {
         parent()
+      } else if (!Config.get().isWebsocketMessagesSeparateTraces()) {
+        childOf(handshake)
       } else {
         if (parentSpan != null) {
           childOf(parentSpan)
@@ -2470,7 +2472,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
         }
       }
       spanType(DDSpanTypes.WEBSOCKET)
-      if (Config.get().isWebsocketMessagesSeparateTraces() || !traceStarter) {
+      if (Config.get().isWebsocketMessagesSeparateTraces()) {
         links {
           link(handshake, linkFlags, linkAttributes)
         }

--- a/dd-java-agent/instrumentation/websocket/jakarta-websocket-2.0/src/test/groovy/WebsocketTest.groovy
+++ b/dd-java-agent/instrumentation/websocket/jakarta-websocket-2.0/src/test/groovy/WebsocketTest.groovy
@@ -431,7 +431,7 @@ class WebsocketTest extends InstrumentationSpecification {
     }
   }
 
-  def "test close and receive on same handshake trace"() {
+  def "test all messages and close on same handshake trace"() {
     setup:
     injectSysConfig(TRACE_WEBSOCKET_MESSAGES_SEPARATE_TRACES, "false")
     when:
@@ -446,14 +446,19 @@ class WebsocketTest extends InstrumentationSpecification {
       session.close()
     }
     then:
-    // in reality we have 3 traces but since the handshake finishes soon, the trace structure writer is collecting 5 chunks
-    assertTraces(5, {
+    // In reality we have 3 traces, but finished handshake traces are reported in separate chunks.
+    assertTraces(7, {
       DDSpan serverHandshake, clientHandshake
       trace(1) {
         basicSpan(it, "http.request", "GET /test", null, null, handshakeTags(url))
         clientHandshake = span(0)
       }
-
+      trace(1) {
+        websocketSendSpan(it, clientHandshake, "text", 5, 1, clientHandshake)
+      }
+      trace(1) {
+        websocketCloseSpan(it, clientHandshake, true, 1000, null, clientHandshake)
+      }
       trace(1) {
         basicSpan(it, "servlet.request", "GET /test", null, null, handshakeTags(url))
         serverHandshake = span(0)
@@ -464,11 +469,8 @@ class WebsocketTest extends InstrumentationSpecification {
       trace(1) {
         websocketCloseSpan(it, serverHandshake, false, 1000, { it == null || it == 'no reason given' }, serverHandshake)
       }
-      trace(3) {
-        sortSpansByStart()
+      trace(1) {
         basicSpan(it, "parent")
-        websocketSendSpan(it, clientHandshake, "text", 5, 1, span(0))
-        websocketCloseSpan(it, clientHandshake, true, 1000, null, span(0))
       }
     })
   }

--- a/dd-java-agent/instrumentation/websocket/javax-websocket-1.0/src/test/groovy/WebsocketTest.groovy
+++ b/dd-java-agent/instrumentation/websocket/javax-websocket-1.0/src/test/groovy/WebsocketTest.groovy
@@ -434,7 +434,7 @@ class WebsocketTest extends InstrumentationSpecification {
     }
   }
 
-  def "test close and receive on same handshake trace"() {
+  def "test all messages and close on same handshake trace"() {
     setup:
     injectSysConfig(TRACE_WEBSOCKET_MESSAGES_SEPARATE_TRACES, "false")
     when:
@@ -449,14 +449,19 @@ class WebsocketTest extends InstrumentationSpecification {
       session.close()
     }
     then:
-    // in reality we have 3 traces but since the handshake finishes soon, the trace structure writer is collecting 5 chunks
-    assertTraces(5, {
+    // In reality we have 3 traces, but finished handshake traces are reported in separate chunks.
+    assertTraces(7, {
       DDSpan serverHandshake, clientHandshake
       trace(1) {
         basicSpan(it, "http.request", "GET /test", null, null, handshakeTags(url))
         clientHandshake = span(0)
       }
-
+      trace(1) {
+        websocketSendSpan(it, clientHandshake, "text", 5, 1, clientHandshake)
+      }
+      trace(1) {
+        websocketCloseSpan(it, clientHandshake, true, 1000, null, clientHandshake)
+      }
       trace(1) {
         basicSpan(it, "servlet.request", "GET /test", null, null, handshakeTags(url))
         serverHandshake = span(0)
@@ -467,11 +472,8 @@ class WebsocketTest extends InstrumentationSpecification {
       trace(1) {
         websocketCloseSpan(it, serverHandshake, false, 1000, { it == null || it == 'no reason given' }, serverHandshake)
       }
-      trace(3) {
-        sortSpansByStart()
+      trace(1) {
         basicSpan(it, "parent")
-        websocketSendSpan(it, clientHandshake, "text", 5, 1, span(0))
-        websocketCloseSpan(it, clientHandshake, true, 1000, null, span(0))
       }
     })
   }


### PR DESCRIPTION
## Summary

- use the handshake span context for outbound WebSocket send and close spans when `DD_TRACE_WEBSOCKET_MESSAGES_SEPARATE_TRACES=false`
- preserve the default separate-trace behavior, where outbound spans follow the active context and link back to the handshake
- extend the shared assertions and both javax/jakarta WebSocket regression suites to cover send and locally initiated close

## Testing

- `:dd-java-agent:instrumentation:websocket:javax-websocket-1.0:test --tests "*WebsocketTest"`
- `:dd-java-agent:instrumentation:websocket:jakarta-websocket-2.0:test --tests "*WebsocketTest"`
- `git diff --check`

The full WebSocket suites pass after temporarily allowing the Guance-specific `trace_128_bit_id` and `dd_ext_version` tags in the common test assertion. That temporary compatibility change is not included here; without it, the current `guance` baseline fails strict tag validation before evaluating this change.
